### PR TITLE
Display two conference abbreviations

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -308,7 +308,7 @@ badges: # Display different badges for your publications
   dimensions_badge: true # Dimensions badge (https://badge.dimensions.ai/)
 
 # Filter out certain bibtex entry keywords used internally from the bib output
-filtered_bibtex_keywords: [abbr, abstract, arxiv, bibtex_show, html, pdf, selected, supp, blog, code, poster, slides, website, preview, altmetric, youtube]
+filtered_bibtex_keywords: [abbr, award, abstract, arxiv, bibtex_show, html, pdf, selected, supp, blog, code, poster, slides, website, preview, altmetric, youtube]
 
 # Maximum number of authors to be shown for each publication (more authors are visible on click)
 max_author_limit: 10  # leave blank to always show all authors

--- a/_layouts/bib.html
+++ b/_layouts/bib.html
@@ -23,6 +23,11 @@
           {%- else -%}
             <abbr class="badge">{{entry.abbr}}</abbr>
           {%- endif -%}
+          {%- if entry.award -%}
+            <abbr class="badge award">{{entry.award}}</abbr>
+          {%- endif -%}
+        {%- elsif entry.award -%}
+          <abbr class="badge award">{{entry.award}}</abbr>
         {%- endif -%}
         </div>
 

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -599,6 +599,7 @@ footer.sticky-bottom {
           background-color: var(--global-theme-color);
           padding-left: 1rem;
           padding-right: 1rem;
+          margin-right: 0.25rem;
 
           a {
             color: white;
@@ -612,6 +613,7 @@ footer.sticky-bottom {
         .award {
           color: var(--global-theme-color) !important;
           border: 1px solid var(--global-theme-color);
+          background-color: transparent;
         }
       }
 


### PR DESCRIPTION
Add support for an optional `award` badge to display alongside the publication venue abbreviation.

This enables displaying both a conference abbreviation (e.g., `abbr={ICCV W.}`) and an award (e.g., `award={Distinguished Paper}`) for a single publication entry, with distinct styling for the award badge.

---
<a href="https://cursor.com/background-agent?bcId=bc-c00536a6-9767-48b2-9e36-17a6f75ecec0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c00536a6-9767-48b2-9e36-17a6f75ecec0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

