### PR TITLE
Fix YAML indentation in CV data file

### DIFF
--- a/_data/cv_jemin.yml
+++ b/_data/cv_jemin.yml
@@ -97,8 +97,8 @@
   type: time_table
   contents:
     - title: System-Model Co-Design for Efficient AI in the Physical World
-    - year: 28 Mar 2026
-    - description: <a href="https://event-us.kr/enerzai/event/121735">AI on Edge – From Bits to Real World 2026</a>
+      year: 28 Mar 2026
+      description: <a href="https://event-us.kr/enerzai/event/121735">AI on Edge – From Bits to Real World 2026</a>
     - title: Quantized LLM Evaluation
       year: 23 May 2025
       description: IeMek ISET Workshop 2025

--- a/_data/cv_jemin.yml
+++ b/_data/cv_jemin.yml
@@ -96,6 +96,9 @@
 - title: Seminar and Talk
   type: time_table
   contents:
+    - title: Physical AI 기술의 해양(수중) 환경 적용 가능성
+      year: 17 Apr 2026
+      description: 선박해양플랜트연구소 (KRISO)
     - title: System-Model Co-Design for Efficient AI in the Physical World
       year: 28 Mar 2026
       description: <a href="https://event-us.kr/enerzai/event/121735">AI on Edge – From Bits to Real World 2026</a>

--- a/_data/cv_jemin.yml
+++ b/_data/cv_jemin.yml
@@ -96,6 +96,9 @@
 - title: Seminar and Talk
   type: time_table
   contents:
+    - title: <a href="https://iemek.org/Conference/ConferenceView.asp?top_param=&sub_param=&AC=0&CODE=CC20260201&CpPage=674#CONF">신진연구자 발표</a>
+      year: 15 May 2026
+      description: IeMeK ISET
     - title: Physical AI 기술의 해양(수중) 환경 적용 가능성
       year: 17 Apr 2026
       description: 선박해양플랜트연구소 (KRISO)


### PR DESCRIPTION
## Summary
Fixed incorrect YAML indentation in the CV data file that was causing parsing issues with the first conference entry.

## Key Changes
- Corrected indentation for the "System-Model Co-Design for Efficient AI in the Physical World" entry
- Aligned `year` and `description` fields to match proper YAML list item formatting
- Ensured consistent indentation with other entries in the time_table section

## Details
The first conference entry had improper indentation where `year` and `description` were at the same level as `title` rather than being nested under it. This has been corrected to follow proper YAML syntax and maintain consistency with the other entries in the list.

https://claude.ai/code/session_0152KmiaAKYevxWm3qdAN61S