### PR TITLE
Photo 페이지 연도별 캐러셀 개편 및 Projects 역할(과제책임자/공동책임자)·용역 표기 추가

### DIFF
--- a/_pages/photos.md
+++ b/_pages/photos.md
@@ -10,17 +10,44 @@ nav_order: 5
 <!-- pages/photos.md -->
 
 <style>
-.photo-board {
-  columns: 2 380px;
-  column-gap: 1.2rem;
-  margin-top: 1rem;
+.photo-year-title {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: var(--global-text-color, #333);
+  border-left: 4px solid var(--global-theme-color, #4285f4);
+  padding-left: 0.8rem;
+  margin-top: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+.photo-carousel-wrap {
+  position: relative;
+}
+
+.photo-carousel {
+  display: flex;
+  gap: 1rem;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  padding: 0.25rem 0.25rem 0.75rem;
+  -webkit-overflow-scrolling: touch;
+}
+
+.photo-carousel::-webkit-scrollbar {
+  height: 8px;
+}
+
+.photo-carousel::-webkit-scrollbar-thumb {
+  background: var(--global-divider-color, #ddd);
+  border-radius: 4px;
 }
 
 .photo-item {
-  display: inline-block;
-  width: 100%;
-  margin: 0 0 1rem;
-  break-inside: avoid;
+  flex: 0 0 auto;
+  width: 300px;
+  margin: 0;
+  scroll-snap-align: start;
 }
 
 .photo-item a {
@@ -40,7 +67,8 @@ nav_order: 5
 .photo-item img {
   display: block;
   width: 100%;
-  height: auto;
+  height: 210px;
+  object-fit: cover;
   transition: transform 0.4s ease;
 }
 
@@ -49,26 +77,122 @@ nav_order: 5
 }
 
 .photo-item figcaption {
-  font-size: 0.75rem;
-  font-family: 'Roboto', monospace;
-  color: var(--global-text-color-light, #555);
   text-align: center;
-  margin-top: 0.35rem;
+  margin-top: 0.5rem;
+  line-height: 1.4;
+}
+
+.photo-item .photo-date {
+  display: block;
+  font-size: 0.85rem;
+  color: var(--global-text-color-light, #666);
+}
+
+.photo-item .photo-event {
+  display: block;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--global-text-color, #333);
+}
+
+.carousel-btn {
+  position: absolute;
+  top: 105px;
+  transform: translateY(-50%);
+  z-index: 2;
+  width: 2.2rem;
+  height: 2.2rem;
+  border-radius: 50%;
+  border: 1px solid var(--global-divider-color, #ddd);
+  background: var(--global-card-bg-color, #fff);
+  color: var(--global-text-color, #333);
+  font-size: 1.2rem;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.9;
+}
+
+.carousel-btn:hover {
+  background: var(--global-theme-color, #4285f4);
+  color: #fff;
+}
+
+.carousel-btn.prev { left: -0.6rem; }
+.carousel-btn.next { right: -0.6rem; }
+
+@media (max-width: 768px) {
+  .photo-item { width: 240px; }
+  .photo-item img { height: 170px; }
+  .carousel-btn { top: 85px; }
 }
 </style>
 
-{% assign photo_files = site.static_files | where_exp: "file", "file.path contains '/assets/img/photos/'" | sort: "path" | reverse %}
-<div class="photo-board">
-{%- for photo in photo_files %}
-  {%- assign ext = photo.extname | downcase %}
-  {%- comment %} .webp 제외: jekyll-imagemagick이 생성하는 반응형 변환본(-480/-800/-1400.webp)이 중복 표시되는 것 방지 {%- endcomment %}
-  {%- if ext == ".jpg" or ext == ".jpeg" or ext == ".png" or ext == ".gif" %}
-  <figure class="photo-item">
-    <a href="{{ photo.path | relative_url }}" target="_blank" rel="noopener">
-      <img src="{{ photo.path | relative_url }}" alt="{{ photo.basename }}" loading="lazy">
-    </a>
-    <figcaption>{{ photo.basename | replace: "_", " " }}</figcaption>
-  </figure>
-  {%- endif %}
-{%- endfor %}
+{%- comment %}
+사진 파일명 규칙: YYYY_M_행사명.확장자 (예: 2026_6_KCC.png → "2026년 6월 / KCC")
+.webp 제외: jekyll-imagemagick이 생성하는 반응형 변환본(-480/-800/-1400.webp)이 중복 표시되는 것 방지
+{%- endcomment %}
+{%- assign photo_files = site.static_files | where_exp: "file", "file.path contains '/assets/img/photos/'" %}
+{%- assign photo_files = photo_files | where_exp: "file", "file.extname == '.jpg' or file.extname == '.jpeg' or file.extname == '.png' or file.extname == '.gif' or file.extname == '.JPG' or file.extname == '.JPEG' or file.extname == '.PNG'" %}
+{%- assign year_groups = photo_files | group_by_exp: "file", "file.basename | split: '_' | first" | sort: "name" | reverse %}
+{%- assign months_desc = "12,11,10,9,8,7,6,5,4,3,2,1" | split: "," %}
+
+{%- for year_group in year_groups %}
+<h4 class="photo-year-title">{{ year_group.name }}</h4>
+<div class="photo-carousel-wrap">
+  <button class="carousel-btn prev" type="button" aria-label="이전 사진">‹</button>
+  <div class="photo-carousel">
+  {%- for m in months_desc %}
+    {%- assign m_num = m | plus: 0 %}
+    {%- for photo in year_group.items %}
+      {%- assign parts = photo.basename | split: "_" %}
+      {%- assign photo_month = parts[1] | plus: 0 %}
+      {%- if photo_month == m_num %}
+      {%- assign event_name = parts | slice: 2, 10 | join: " " %}
+      <figure class="photo-item">
+        <a href="{{ photo.path | relative_url }}" target="_blank" rel="noopener">
+          <img src="{{ photo.path | relative_url }}" alt="{{ event_name | default: photo.basename }}" loading="lazy">
+        </a>
+        <figcaption>
+          <span class="photo-date">{{ parts[0] }}년 {{ photo_month }}월</span>
+          <span class="photo-event">{{ event_name | default: photo.basename }}</span>
+        </figcaption>
+      </figure>
+      {%- endif %}
+    {%- endfor %}
+  {%- endfor %}
+  {%- comment %} 파일명이 YYYY_M_행사명 규칙을 따르지 않는 사진은 마지막에 표시 {%- endcomment %}
+  {%- for photo in year_group.items %}
+    {%- assign parts = photo.basename | split: "_" %}
+    {%- assign photo_month = parts[1] | plus: 0 %}
+    {%- if photo_month < 1 or photo_month > 12 %}
+      <figure class="photo-item">
+        <a href="{{ photo.path | relative_url }}" target="_blank" rel="noopener">
+          <img src="{{ photo.path | relative_url }}" alt="{{ photo.basename }}" loading="lazy">
+        </a>
+        <figcaption>
+          <span class="photo-event">{{ photo.basename | replace: "_", " " }}</span>
+        </figcaption>
+      </figure>
+    {%- endif %}
+  {%- endfor %}
+  </div>
+  <button class="carousel-btn next" type="button" aria-label="다음 사진">›</button>
 </div>
+{%- endfor %}
+
+<script>
+  document.querySelectorAll('.photo-carousel-wrap .carousel-btn').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var carousel = btn.closest('.photo-carousel-wrap').querySelector('.photo-carousel');
+      var amount = Math.max(carousel.clientWidth * 0.8, 320);
+      carousel.scrollBy({
+        left: btn.classList.contains('next') ? amount : -amount,
+        behavior: 'smooth'
+      });
+    });
+  });
+</script>

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -71,6 +71,32 @@ a.project-block:focus {
   color: var(--global-text-color);
 }
 
+.project-block h3 .project-contract {
+  font-weight: 600;
+  color: var(--global-text-color-light, #666);
+}
+
+.project-block .project-badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  vertical-align: middle;
+  margin-left: 0.45rem;
+  white-space: nowrap;
+}
+
+.project-block .badge-pi {
+  background: var(--global-theme-color, #4285f4);
+  color: #fff;
+}
+
+.project-block .badge-copi {
+  background: var(--global-divider-color, #e5e5e5);
+  color: var(--global-text-color, #333);
+}
+
 a.project-block:hover h3 {
   color: var(--global-theme-color);
 }
@@ -133,7 +159,7 @@ a.project-block:hover h3 {
       {%- endif %}
     </div>
     <div class="text-col">
-      <h3>{{ project.title }}</h3>
+      <h3>{{ project.title }}{%- if project.project_type %} <span class="project-contract">({{ project.project_type }})</span>{%- endif %}{%- if project.role %}<span class="project-badge {% if project.role == '과제책임자' %}badge-pi{% else %}badge-copi{% endif %}">{{ project.role }}</span>{%- endif %}</h3>
       <p class="project-desc">{{ project.description }}</p>
       {%- if project.period or project.funded_by %}
       <p class="project-meta">

--- a/_research/10_research.md
+++ b/_research/10_research.md
@@ -9,6 +9,8 @@ category: Present
 period: "Aug. 2026 – Nov. 2026"
 # funding: "TBD"
 funded_by: "ETRI"
+role: "과제책임자"
+project_type: "용역"
 ---
 
 <div class="col-sm mt-3 mt-md-0">

--- a/_research/1_research.md
+++ b/_research/1_research.md
@@ -9,6 +9,7 @@ category: Past
 period: "Jun. 2023 – Dec. 2027"
 # funding: "~10M USD"
 funded_by: "IITP"
+role: "과제책임자"
 ---
 
 <div class="col-sm mt-3 mt-md-0">

--- a/_research/2_research.md
+++ b/_research/2_research.md
@@ -7,6 +7,7 @@ sponsor_logo: assets/img/logo/nrf-logo.png
 importance: 2
 category: Past
 funded_by: "NRF (한국연구재단)"
+role: "과제책임자"
 ---
 
 Every project has a beautiful feature showcase page.

--- a/_research/3_research.md
+++ b/_research/3_research.md
@@ -9,6 +9,7 @@ category: Past
 period: "Jan. 2018 – Dec. 2022"
 # funding: "3M USD/year"
 funded_by: "IITP"
+role: "과제책임자"
 ---
 
 <img src="https://leejaymin.github.io/assets/img/nestc.png" width="90%" height="90%"/>

--- a/_research/4_research.md
+++ b/_research/4_research.md
@@ -9,6 +9,7 @@ category: Present
 period: "Apr. 2026 – Feb. 2027"
 # funding: "30,000,000 KRW"
 funded_by: "Jeonbuk National University"
+role: "과제책임자"
 ---
 
 <div class="col-sm mt-3 mt-md-0">

--- a/_research/5_research.md
+++ b/_research/5_research.md
@@ -9,6 +9,8 @@ category: Present
 period: "May 2026 – Nov. 2026"
 # funding: "50,000,000 KRW"
 funded_by: "ETRI"
+role: "과제책임자"
+project_type: "용역"
 ---
 
 <div class="col-sm mt-3 mt-md-0">

--- a/_research/6_research.md
+++ b/_research/6_research.md
@@ -9,6 +9,7 @@ category: Present
 period: "Jun. 2026 – Aug. 2026"
 # funding: "4,000,000 KRW"
 funded_by: "Jeonbuk National University"
+role: "과제책임자"
 ---
 
 <div class="col-sm mt-3 mt-md-0">

--- a/_research/7_research.md
+++ b/_research/7_research.md
@@ -9,6 +9,7 @@ category: Present
 period: "Jul. 2026 – Dec. 2030"
 # funding: "TBD"
 funded_by: "KEIT"
+role: "공동책임자"
 ---
 
 <div class="col-sm mt-3 mt-md-0">

--- a/_research/8_research.md
+++ b/_research/8_research.md
@@ -9,6 +9,7 @@ category: Present
 period: "Jul. 2026 – Dec. 2031"
 # funding: "TBD"
 funded_by: "IITP"
+role: "공동책임자"
 ---
 
 <div class="col-sm mt-3 mt-md-0">

--- a/_research/9_research.md
+++ b/_research/9_research.md
@@ -9,6 +9,7 @@ category: Present
 period: "Aug. 2026 – Jan. 2028"
 # funding: "TBD"
 funded_by: "Jeonbuk National University"
+role: "과제책임자"
 ---
 
 <div class="col-sm mt-3 mt-md-0">


### PR DESCRIPTION
- Photo: 사진 크기를 줄이고 연도별로 묶어 좌우로 넘겨보는 캐러셀 방식으로 변경
- Photo: 파일명(YYYY_M_행사명)을 파싱해 '2026년 6월' 형식의 날짜와 행사명을 표기하고 글씨 크기 확대
- Projects: 각 과제에 role 필드를 추가해 과제책임자/공동책임자 배지 표시 (KEIT, AI스타펠로우십은 공동책임자)
- Projects: ETRI 과제는 제목에 (용역) 표기

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01N7TmYHkTXjYiyN5os9d2hb