### PR TITLE
학회 마감일(Deadlines) 페이지 추가 및 상류 데이터 주간 자동 동기화

### DIFF
--- a/.github/workflows/sync-deadlines.yml
+++ b/.github/workflows/sync-deadlines.yml
@@ -1,0 +1,47 @@
+name: Sync conference deadlines
+
+# 상류 저장소의 학회 마감일 데이터를 주기적으로 가져와 _data/conferences.yml 을 갱신한다.
+# 변경이 있으면 PR 을 열고, 사람이 머지하면 deploy.yml 이 사이트를 다시 배포한다.
+# (자동 커밋을 master 로 직접 push 하면 GITHUB_TOKEN 으로 만든 push 는 다른
+#  워크플로를 트리거하지 않으므로 배포가 돌지 않는다.)
+
+on:
+  schedule:
+    - cron: "0 20 * * 0" # 매주 월요일 05:00 KST (cron 은 UTC 기준)
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install dependencies
+        run: pip install pyyaml tzdata
+
+      - name: Sync deadlines from upstream
+        run: python3 bin/sync_deadlines.py
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: chore/sync-deadlines
+          delete-branch: true
+          add-paths: _data/conferences.yml
+          commit-message: "학회 마감일 데이터 자동 동기화"
+          title: "학회 마감일 데이터 자동 동기화"
+          body: |
+            `bin/sync_deadlines.py` 가 상류 저장소에서 학회 마감일을 가져와 갱신했습니다.
+
+            - https://github.com/huggingface/ai-deadlines (AI 학회)
+            - https://github.com/casys-kaist/casys-kaist.github.io (시스템/아키텍처 학회)
+
+            변경된 마감일이 맞는지 확인 후 머지해 주세요. 머지되면 사이트가 자동 배포됩니다.

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,0 +1,1931 @@
+# 이 파일은 bin/sync_deadlines.py 가 생성한다. 직접 수정하지 말 것.
+#
+# 출처:
+#   - https://github.com/huggingface/ai-deadlines (MIT License)
+#   - https://github.com/casys-kaist/casys-kaist.github.io
+#
+# 갱신: .github/workflows/sync-deadlines.yml 이 매주 실행하며,
+#       수동 실행은 `python3 bin/sync_deadlines.py`.
+
+- id: icdm26
+  title: ICDM
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - data-mining
+  deadlines:
+  - type: abstract
+    label: Abstract Submission
+    date: '2026-05-30 23:59:59'
+    timezone: AoE
+    utc: '2026-05-31T11:59:59Z'
+  - type: paper
+    label: Full Paper Submission
+    date: '2026-06-06 23:59:59'
+    timezone: AoE
+    utc: '2026-06-07T11:59:59Z'
+  - type: notification
+    label: Author Notification
+    date: '2026-08-16 23:59:59'
+    timezone: AoE
+    utc: '2026-08-17T11:59:59Z'
+  - type: camera_ready
+    label: Camera Ready Deadline
+    date: '2026-09-09 23:59:59'
+    timezone: AoE
+    utc: '2026-09-10T11:59:59Z'
+  source: ai-deadlines
+  full_name: International Conference on Data Mining
+  link: http://icdm2026.neu.edu.cn/
+  place: Shenyang, China
+  date: November 12 - 15, 2026
+  start: '2026-11-12'
+  end: '2026-11-15'
+  next_deadline: '2026-08-17T11:59:59Z'
+- id: wsdm27
+  title: WSDM
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - data-mining
+  - web-search
+  deadlines:
+  - type: abstract
+    label: Abstract submission (full papers)
+    date: '2026-08-17 23:59:59'
+    timezone: AoE
+    utc: '2026-08-18T11:59:59Z'
+  - type: paper
+    label: Paper submission (full papers)
+    date: '2026-08-24 23:59:59'
+    timezone: AoE
+    utc: '2026-08-25T11:59:59Z'
+  - type: notification
+    label: Author notification (full papers)
+    date: '2026-11-02 23:59:59'
+    timezone: AoE
+    utc: '2026-11-03T11:59:59Z'
+  - type: paper
+    label: Paper submission (short papers)
+    date: '2026-11-17 23:59:59'
+    timezone: AoE
+    utc: '2026-11-18T11:59:59Z'
+  - type: notification
+    label: Author notification (short papers)
+    date: '2026-12-18 23:59:59'
+    timezone: AoE
+    utc: '2026-12-19T11:59:59Z'
+  source: ai-deadlines
+  full_name: ACM International Conference on Web Search and Data Mining
+  link: https://www.wsdm-conference.org/2027/
+  place: Hong Kong, Hong Kong
+  date: February 15-19, 2027
+  start: '2027-02-15'
+  end: '2027-02-19'
+  next_deadline: '2026-08-18T11:59:59Z'
+- id: cikm26
+  title: CIKM
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - data-mining
+  - machine-learning
+  - web-search
+  deadlines:
+  - type: abstract
+    label: Abstract submission deadline
+    date: '2026-05-16 23:59:00'
+    timezone: AoE
+    utc: '2026-05-17T11:59:00Z'
+  - type: paper
+    label: Full paper submission deadline
+    date: '2026-05-23 23:59:00'
+    timezone: AoE
+    utc: '2026-05-24T11:59:00Z'
+  - type: notification
+    label: Author notification
+    date: '2026-08-07 23:59:00'
+    timezone: AoE
+    utc: '2026-08-08T11:59:00Z'
+  - type: camera_ready
+    label: Camera-ready deadline
+    date: '2026-08-20 23:59:00'
+    timezone: AoE
+    utc: '2026-08-21T11:59:00Z'
+  source: ai-deadlines
+  full_name: Conference on Information and Knowledge Management
+  link: https://cikm2026.diag.uniroma1.it/
+  place: Rome, Italy
+  date: November 7-11, 2026
+  start: '2026-11-07'
+  end: '2026-11-11'
+  note: All deadlines are at 11:59pm AoE
+  hindex: 91.0
+  next_deadline: '2026-08-21T11:59:00Z'
+- id: acm26
+  title: ACM MM
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - computer-vision
+  - human-computer-interaction
+  - machine-learning
+  deadlines:
+  - type: abstract
+    label: Contribution registration
+    date: '2026-03-25 23:59:59'
+    timezone: AoE
+    utc: '2026-03-26T11:59:59Z'
+  - type: paper
+    label: Contribution submission
+    date: '2026-04-01 23:59:59'
+    timezone: AoE
+    utc: '2026-04-02T11:59:59Z'
+  - type: supplementary
+    label: Supplementary material submission
+    date: '2026-04-08 23:59:59'
+    timezone: AoE
+    utc: '2026-04-09T11:59:59Z'
+  - type: rebuttal_start
+    label: Rebuttal period start
+    date: '2026-06-04 23:59:59'
+    timezone: AoE
+    utc: '2026-06-05T11:59:59Z'
+  - type: notification
+    label: Author notification
+    date: '2026-07-09 23:59:59'
+    timezone: AoE
+    utc: '2026-07-10T11:59:59Z'
+  - type: camera_ready
+    label: Camera-ready submission
+    date: '2026-08-06 23:59:59'
+    timezone: AoE
+    utc: '2026-08-07T11:59:59Z'
+  - type: registration
+    label: Author registration
+    date: '2026-08-20 23:59:59'
+    timezone: AoE
+    utc: '2026-08-21T11:59:59Z'
+  source: ai-deadlines
+  full_name: ACM Multimedia
+  link: https://2026.acmmm.org/
+  place: Rio de Janeiro, Brazil
+  date: November 10-14, 2026
+  start: '2026-11-10'
+  end: '2026-11-14'
+  note: All important dates can be found <a href='https://2026.acmmm.org/site/important-dates.html'>here</a>.
+    The time for all dates is 23:59 AoE (Anywhere-on-Earth).
+  next_deadline: '2026-08-21T11:59:59Z'
+- id: emnlp26
+  title: EMNLP
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - natural-language-processing
+  deadlines:
+  - type: paper
+    label: Paper submission deadline
+    date: '2026-05-25 23:59:59'
+    timezone: AoE
+    utc: '2026-05-26T11:59:59Z'
+  - type: reviewer_registration
+    label: Reviewer registration deadline
+    date: '2026-05-27 23:59:59'
+    timezone: AoE
+    utc: '2026-05-28T11:59:59Z'
+  - type: rebuttal_start
+    label: Author response period start
+    date: '2026-07-07 23:59:59'
+    timezone: AoE
+    utc: '2026-07-08T11:59:59Z'
+  - type: rebuttal_end
+    label: Author response period end
+    date: '2026-07-13 23:59:59'
+    timezone: AoE
+    utc: '2026-07-14T11:59:59Z'
+  - type: review_release
+    label: Meta review release
+    date: '2026-07-30 23:59:59'
+    timezone: AoE
+    utc: '2026-07-31T11:59:59Z'
+  - type: commitment_deadline
+    label: EMNLP commitment deadline
+    date: '2026-08-02 23:59:59'
+    timezone: AoE
+    utc: '2026-08-03T11:59:59Z'
+  - type: notification
+    label: Author notification date
+    date: '2026-08-20 23:59:59'
+    timezone: AoE
+    utc: '2026-08-21T11:59:59Z'
+  - type: camera_ready
+    label: Camera-ready deadline
+    date: '2026-08-30 23:59:59'
+    timezone: AoE
+    utc: '2026-08-31T11:59:59Z'
+  source: ai-deadlines
+  full_name: The annual Conference on Empirical Methods in Natural Language Processing
+  link: https://2026.emnlp.org/
+  place: Budapest, Hungary
+  date: October 24 - 29, 2026
+  start: '2026-10-24'
+  end: '2026-10-29'
+  next_deadline: '2026-08-21T11:59:59Z'
+- id: wacv27
+  title: WACV
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - computer-vision
+  - machine-learning
+  deadlines:
+  - type: registration
+    label: Round 1 Paper Registration
+    date: '2026-06-19 23:59:59'
+    timezone: AoE
+    utc: '2026-06-20T11:59:59Z'
+  - type: submission
+    label: Round 1 Paper Submission
+    date: '2026-06-26 23:59:59'
+    timezone: AoE
+    utc: '2026-06-27T11:59:59Z'
+  - type: supplementary
+    label: Round 1 Supplementary Material
+    date: '2026-06-28 23:59:59'
+    timezone: AoE
+    utc: '2026-06-29T11:59:59Z'
+  - type: review_release
+    label: Round 1 Reviews and Decisions To Authors
+    date: '2026-08-09 23:59:59'
+    timezone: AoE
+    utc: '2026-08-10T11:59:59Z'
+  - type: rebuttal_and_revision
+    label: Round 1 Rebuttal and Revision Submission
+    date: '2026-08-21 23:59:59'
+    timezone: AoE
+    utc: '2026-08-22T11:59:59Z'
+  - type: registration
+    label: Round 2 New Paper Registration
+    date: '2026-08-21 23:59:59'
+    timezone: AoE
+    utc: '2026-08-22T11:59:59Z'
+  - type: submission
+    label: Round 2 Paper Submissions
+    date: '2026-08-28 23:59:59'
+    timezone: AoE
+    utc: '2026-08-29T11:59:59Z'
+  - type: supplementary
+    label: Round 2 Supplemental Material
+    date: '2026-08-30 23:59:59'
+    timezone: AoE
+    utc: '2026-08-31T11:59:59Z'
+  - type: notification
+    label: Round 2 Reviews and Final Decisions to Authors
+    date: '2026-10-09 23:59:59'
+    timezone: AoE
+    utc: '2026-10-10T11:59:59Z'
+  - type: notification
+    label: Round 1 Final Decisions Released to Authors
+    date: '2026-10-09 23:59:59'
+    timezone: AoE
+    utc: '2026-10-10T11:59:59Z'
+  - type: camera_ready
+    label: Camera Ready Both Rounds
+    date: '2026-11-02 23:59:59'
+    timezone: AoE
+    utc: '2026-11-03T11:59:59Z'
+  source: ai-deadlines
+  full_name: IEEE/CVF Winter Conference on Applications of Computer Vision
+  link: https://wacv.thecvf.com/
+  place: Buena Vista, FL, USA
+  date: January 4 - January 8, 2027
+  start: '2027-01-04'
+  end: '2027-01-08'
+  hindex: 131
+  next_deadline: '2026-08-22T11:59:59Z'
+- id: 3dv27
+  title: 3DV
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - computer-vision
+  - machine-learning
+  deadlines:
+  - type: submission
+    label: Paper Submission Deadline
+    date: '2026-08-28 11:00:00'
+    timezone: UTC-7
+    utc: '2026-08-28T18:00:00Z'
+  - type: supplementary
+    label: Supplementary Material Deadline
+    date: '2026-09-02 11:00:00'
+    timezone: UTC-7
+    utc: '2026-09-02T18:00:00Z'
+  - type: notification
+    label: Preliminary Notification
+    date: '2026-10-27 11:00:00'
+    timezone: UTC-7
+    utc: '2026-10-27T18:00:00Z'
+  - type: notification
+    label: Final Notification
+    date: '2026-12-02 11:00:00'
+    timezone: UTC-7
+    utc: '2026-12-02T18:00:00Z'
+  source: ai-deadlines
+  full_name: International Conference on 3D Vision
+  link: https://3dvconf.github.io/2027/
+  place: Thessaloniki, Greece
+  date: April 6-9, 2027
+  start: '2027-04-06'
+  end: '2027-04-09'
+  next_deadline: '2026-08-28T18:00:00Z'
+- id: asplos27summer
+  title: ASPLOS (September)
+  year: 2027
+  areas:
+  - Systems
+  tags:
+  - computer-architecture
+  - systems
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-09-09 23:59:59'
+    timezone: UTC-12
+    utc: '2026-09-10T11:59:59Z'
+  source: casys
+  link: https://www.asplos-conference.org/asplos2027/cfp/
+  place: Crete, Greece
+  date: April 11-15, 2027
+  start: '2027-04-11'
+  end: '2027-04-15'
+  next_deadline: '2026-09-10T11:59:59Z'
+- id: NSDI27fall
+  title: NSDI (Fall)
+  year: 2027
+  areas:
+  - Systems
+  tags:
+  - systems
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2026-09-10 23:59:59'
+    timezone: UTC-4
+    utc: '2026-09-11T03:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2026-09-17 23:59:59'
+    timezone: UTC-4
+    utc: '2026-09-18T03:59:59Z'
+  source: casys
+  link: https://www.usenix.org/conference/nsdi27/call-for-papers
+  place: Providence, RI, USA
+  date: May 11-13, 2027
+  start: '2027-05-11'
+  end: '2027-05-13'
+  next_deadline: '2026-09-11T03:59:59Z'
+- id: fast27
+  title: FAST
+  year: 2027
+  areas:
+  - Systems
+  tags:
+  - systems
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-09-15 23:59:59'
+    timezone: UTC-7
+    utc: '2026-09-16T06:59:59Z'
+  source: casys
+  link: https://www.usenix.org/conference/fast27
+  place: Renton, WA, USA
+  date: February 23-25, 2027
+  start: '2027-02-23'
+  end: '2027-02-25'
+  next_deadline: '2026-09-16T06:59:59Z'
+- id: DATE27
+  title: DATE
+  year: 2027
+  areas:
+  - Systems
+  tags:
+  - computer-architecture
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-09-15 23:59:59'
+    timezone: UTC-12
+    utc: '2026-09-16T11:59:59Z'
+  source: casys
+  link: https://www.date-conference.com/date-2027-call-papers
+  place: TBD
+  date: TBD
+  tba: true
+  next_deadline: '2026-09-16T11:59:59Z'
+- id: eurosys27fall
+  title: EuroSys (Fall)
+  year: 2027
+  areas:
+  - Systems
+  tags:
+  - systems
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2026-09-17 23:59:59'
+    timezone: UTC-12
+    utc: '2026-09-18T11:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2026-09-24 23:59:59'
+    timezone: UTC-12
+    utc: '2026-09-25T11:59:59Z'
+  source: casys
+  link: https://2027.eurosys.org/cfp.html
+  place: Rabat, Morocco
+  date: April 19-24, 2027
+  start: '2027-04-19'
+  end: '2027-04-24'
+  next_deadline: '2026-09-18T11:59:59Z'
+- id: neurips26
+  title: NeurIPS
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - machine-learning
+  deadlines:
+  - type: abstract
+    label: Abstract registration deadline
+    date: '2026-05-04 23:59:59'
+    timezone: AoE
+    utc: '2026-05-05T11:59:59Z'
+  - type: paper
+    label: Paper submission deadline
+    date: '2026-05-06 23:59:59'
+    timezone: AoE
+    utc: '2026-05-07T11:59:59Z'
+  - type: supplementary
+    label: Supplementary materials deadline
+    date: '2026-05-06 23:59:59'
+    timezone: AoE
+    utc: '2026-05-07T11:59:59Z'
+  - type: review_release
+    label: Reviews released to authors
+    date: '2026-07-22 23:59:59'
+    timezone: AoE
+    utc: '2026-07-23T11:59:59Z'
+  - type: rebuttal_start
+    label: Author + Reviewer + AC Discussion Period starts
+    date: '2026-07-27 00:00:00'
+    timezone: AoE
+    utc: '2026-07-27T12:00:00Z'
+  - type: rebuttal_end
+    label: Author + Reviewer + AC Discussion Period ends
+    date: '2026-08-03 23:59:59'
+    timezone: AoE
+    utc: '2026-08-04T11:59:59Z'
+  - type: notification
+    label: Author notification
+    date: '2026-09-24 23:59:59'
+    timezone: AoE
+    utc: '2026-09-25T11:59:59Z'
+  source: ai-deadlines
+  full_name: Conference on Neural Information Processing Systems
+  link: https://neurips.cc/
+  place: Sydney, Australia
+  date: December 6-12, 2026
+  start: '2026-12-06'
+  end: '2026-12-12'
+  next_deadline: '2026-09-25T11:59:59Z'
+- id: eurographics27
+  title: Eurographics
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - computer-graphics
+  deadlines:
+  - type: abstract
+    label: Abstract and submission form deadline
+    date: '2026-09-25 23:59:59'
+    timezone: UTC
+    utc: '2026-09-25T23:59:59Z'
+  - type: paper
+    label: Full paper submission deadline
+    date: '2026-10-01 23:59:59'
+    timezone: UTC
+    utc: '2026-10-01T23:59:59Z'
+  - type: review_release
+    label: Reviews released
+    date: '2026-11-23 23:59:59'
+    timezone: UTC
+    utc: '2026-11-23T23:59:59Z'
+  - type: rebuttal
+    label: Rebuttal due
+    date: '2026-11-30 23:59:59'
+    timezone: UTC
+    utc: '2026-11-30T23:59:59Z'
+  - type: notification
+    label: Conditional acceptance or rejection notification
+    date: '2026-12-18 23:59:59'
+    timezone: UTC
+    utc: '2026-12-18T23:59:59Z'
+  - type: camera_ready
+    label: Revised version deadline
+    date: '2027-01-26 23:59:59'
+    timezone: UTC
+    utc: '2027-01-26T23:59:59Z'
+  - type: notification
+    label: Final notification
+    date: '2027-02-09 23:59:59'
+    timezone: UTC
+    utc: '2027-02-09T23:59:59Z'
+  - type: camera_ready
+    label: Camera-ready version due
+    date: '2027-02-23 23:59:59'
+    timezone: UTC
+    utc: '2027-02-23T23:59:59Z'
+  source: ai-deadlines
+  full_name: The 48th Annual Conference of the European Association for Computer Graphics
+  link: https://eg2027.isti.cnr.it/
+  place: Lucca, Italy
+  date: May 10 - 14, 2027
+  start: '2027-05-10'
+  end: '2027-05-14'
+  next_deadline: '2026-09-25T23:59:59Z'
+- id: naacl27
+  title: NAACL
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - natural-language-processing
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-10-12 23:59:59'
+    timezone: AoE
+    utc: '2026-10-13T11:59:59Z'
+  source: ai-deadlines
+  full_name: The Annual Conference of the Nations of the Americas Chapter of the Association for Computational
+    Linguistics
+  link: https://2027.naacl.org/
+  place: San Francisco, USA
+  date: June 1-5, 2027
+  start: '2027-06-01'
+  end: '2027-06-05'
+  note: All submissions must be done through ARR. More info <a href='https://2027.naacl.org/'>here</a>.
+  hindex: 132
+  next_deadline: '2026-10-13T11:59:59Z'
+- id: mlsys27
+  title: MLSys
+  year: 2027
+  areas:
+  - Systems
+  tags:
+  - computer-architecture
+  - systems
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-10-30 12:59:59'
+    timezone: UTC-7
+    utc: '2026-10-30T19:59:59Z'
+  source: casys
+  link: https://mlsys.org/
+  place: TBD
+  date: TBD
+  tba: true
+  next_deadline: '2026-10-30T19:59:59Z'
+- id: isca27
+  title: ISCA
+  year: 2027
+  areas:
+  - Systems
+  tags:
+  - computer-architecture
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-11-17 23:59:59'
+    timezone: UTC-12
+    utc: '2026-11-18T11:59:59Z'
+  source: casys
+  link: https://www.iscaconf.org/isca2027/submit/papers.php
+  place: TBD
+  date: TBD
+  tba: true
+  next_deadline: '2026-11-18T11:59:59Z'
+- id: dac27
+  title: DAC
+  year: 2027
+  areas:
+  - Systems
+  tags:
+  - computer-architecture
+  - systems
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-11-18 16:59:59'
+    timezone: UTC-7
+    utc: '2026-11-18T23:59:59Z'
+  source: casys
+  link: https://www.dac.com/Conference/2026-Call-for-Contributions
+  place: San Jose, CA, USA
+  date: July 10-16, 2027
+  start: '2027-07-10'
+  end: '2027-07-16'
+  tba: true
+  next_deadline: '2026-11-18T23:59:59Z'
+- id: osdi27
+  title: OSDI
+  year: 2027
+  areas:
+  - Systems
+  tags:
+  - systems
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-12-11 17:59:59'
+    timezone: UTC-5
+    utc: '2026-12-11T22:59:59Z'
+  source: casys
+  link: https://www.usenix.org/conference/osdi27
+  place: Baltimore, MD, USA
+  date: July 7-9, 2027
+  start: '2027-07-07'
+  end: '2027-07-09'
+  tba: true
+  next_deadline: '2026-12-11T22:59:59Z'
+- id: cec2027
+  title: CEC
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - machine-learning
+  deadlines:
+  - type: paper
+    label: Paper submission deadline
+    date: '2027-01-15 23:59:59'
+    timezone: AoE
+    utc: '2027-01-16T11:59:59Z'
+  source: ai-deadlines
+  full_name: IEEE Congress on Evolutionary Computation
+  link: http://ieeecec.org
+  place: Edinburgh, United Kingdom
+  date: July 25-28, 2027
+  start: '2027-07-25'
+  end: '2027-07-28'
+  next_deadline: '2027-01-16T11:59:59Z'
+- id: aaai27
+  title: AAAI
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - computer-vision
+  - data-mining
+  - machine-learning
+  - natural-language-processing
+  deadlines: []
+  source: ai-deadlines
+  full_name: AAAI Conference on Artificial Intelligence
+  link: https://aaai.org/conference/aaai/aaai-27/
+  place: Montréal, Canada
+  date: February 16 - 23, 2027
+  start: '2027-02-16'
+  end: '2027-02-23'
+  note: Submission deadlines not yet announced. More info <a href='https://aaai.org/conference/aaai/aaai-27/'>here</a>.
+  hindex: 220
+- id: apsys26
+  title: APSys
+  year: 2026
+  areas:
+  - Systems
+  tags:
+  - systems
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2026-05-13 23:59:59'
+    timezone: AoE
+    utc: '2026-05-14T11:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2026-05-20 23:59:59'
+    timezone: AoE
+    utc: '2026-05-21T11:59:59Z'
+  source: casys
+  link: https://apsys26.github.io/call_for_papers.html
+  place: Bangkok, Thailand
+  date: September 17 - 18, 2026
+  start: '2026-09-17'
+  end: '2026-09-18'
+- id: asplos27spring
+  title: ASPLOS (April)
+  year: 2027
+  areas:
+  - Systems
+  tags:
+  - computer-architecture
+  - systems
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-04-15 23:59:59'
+    timezone: UTC-12
+    utc: '2026-04-16T11:59:59Z'
+  source: casys
+  link: https://www.asplos-conference.org/asplos2027/cfp/
+  place: Crete, Greece
+  date: April 11-15, 2027
+  start: '2027-04-11'
+  end: '2027-04-15'
+- id: asplos26spring
+  title: ASPLOS (Spring)
+  year: 2026
+  areas:
+  - Systems
+  tags:
+  - computer-architecture
+  - systems
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2025-03-12 23:59:59'
+    timezone: UTC-5
+    utc: '2025-03-13T04:59:59Z'
+  source: casys
+  link: https://www.asplos-conference.org/asplos2026/cfp/
+  place: Pittsburgh, USA
+  date: March 22-26, 2026.
+- id: asplos26summer
+  title: ASPLOS (Summer)
+  year: 2026
+  areas:
+  - Systems
+  tags:
+  - computer-architecture
+  - systems
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2025-08-20 23:59:59'
+    timezone: UTC-5
+    utc: '2025-08-21T04:59:59Z'
+  source: casys
+  link: https://www.asplos-conference.org/asplos2026/cfp/
+  place: Pittsburgh, USA
+  date: March 22-26, 2026.
+- id: atc26
+  title: ATC
+  year: 2026
+  areas:
+  - Systems
+  tags:
+  - systems
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-06-10 23:59:59'
+    timezone: UTC-12
+    utc: '2026-06-11T11:59:59Z'
+  source: casys
+  link: https://sigops.org/s/conferences/atc/2026/
+  place: Shatin, Hong Kong
+  date: November 15-18, 2026
+  start: '2026-11-15'
+  end: '2026-11-18'
+- id: chi27
+  title: CHI
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - human-computer-interaction
+  deadlines: []
+  source: ai-deadlines
+  full_name: The ACM Conference on Human Factors in Computing Systems
+  link: https://chi2027.acm.org/
+  place: Pittsburgh, United States
+  date: May 10 - May 14, 2027
+  start: '2027-05-10'
+  end: '2027-05-14'
+  note: Submission deadlines to be announced. More info <a href='https://chi2027.acm.org/'>here</a>.
+  hindex: 128
+- id: colm26
+  title: COLM
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - large-language-models
+  - natural-language-processing
+  deadlines:
+  - type: abstract
+    label: Abstract Submission
+    date: '2026-03-26 23:59:59'
+    timezone: AoE
+    utc: '2026-03-27T11:59:59Z'
+  - type: paper
+    label: Paper Submission
+    date: '2026-03-31 23:59:59'
+    timezone: AoE
+    utc: '2026-04-01T11:59:59Z'
+  - type: rebuttal_start
+    label: Rebuttal Period Start
+    date: '2026-05-22 00:00:00'
+    timezone: AoE
+    utc: '2026-05-22T12:00:00Z'
+  - type: rebuttal_end
+    label: Rebuttal Period End
+    date: '2026-06-08 23:59:59'
+    timezone: AoE
+    utc: '2026-06-09T11:59:59Z'
+  - type: notification
+    label: Decision Notification
+    date: '2026-07-08 23:59:59'
+    timezone: AoE
+    utc: '2026-07-09T11:59:59Z'
+  source: ai-deadlines
+  full_name: Conference on Language Modeling
+  link: https://colmweb.org/
+  place: San Francisco, USA
+  date: October 6-9, 2026
+  start: '2026-10-06'
+  end: '2026-10-09'
+- id: cvpr27
+  title: CVPR
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - computer-vision
+  - machine-learning
+  - optimization-methods
+  - representation-learning
+  - robotics
+  deadlines: []
+  source: ai-deadlines
+  full_name: IEEE/CVF Conference on Computer Vision and Pattern Recognition
+  link: https://cvpr.thecvf.com/
+  place: Seattle, USA
+  date: June 19-26, 2027
+  start: '2027-06-19'
+  end: '2027-06-26'
+  note: Submission deadlines to be announced.
+  hindex: 450
+- id: collas26
+  title: CoLLAs
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - lifelong-learning
+  - machine-learning
+  deadlines:
+  - type: abstract
+    label: Abstract registration deadline
+    date: '2026-04-10 11:59:00'
+    timezone: AoE
+    utc: '2026-04-10T23:59:00Z'
+  - type: paper
+    label: Paper submission deadline
+    date: '2026-04-15 11:59:00'
+    timezone: AoE
+    utc: '2026-04-15T23:59:00Z'
+  source: ai-deadlines
+  full_name: Fifth Conference on Lifelong Learning Agents
+  link: https://lifelong-ml.cc
+  place: Bucharest, Romania
+  date: September 14-17, 2026
+  start: '2026-09-14'
+  end: '2026-09-17'
+- id: corl26
+  title: CoRL
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - machine-learning
+  - robotics
+  deadlines:
+  - type: abstract
+    label: Abstract submission deadline
+    date: '2026-05-26 11:59:00'
+    timezone: UTC
+    utc: '2026-05-26T11:59:00Z'
+  - type: paper
+    label: Paper submission deadline
+    date: '2026-05-29 11:59:00'
+    timezone: UTC
+    utc: '2026-05-29T11:59:00Z'
+  source: ai-deadlines
+  full_name: The Conference on Robot Learning
+  link: https://www.corl.org/
+  place: Austin, United States
+  date: November 9-12, 2026
+  start: '2026-11-09'
+  end: '2026-11-12'
+  note: Workshops on Nov 9, main conference Nov 10-12
+- id: ecai26
+  title: ECAI
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - machine-learning
+  deadlines:
+  - type: abstract
+    label: Abstract submission deadline
+    date: '2026-01-12 23:59:59'
+    timezone: AoE
+    utc: '2026-01-13T11:59:59Z'
+  - type: paper
+    label: Full paper submission deadline
+    date: '2026-01-19 23:59:59'
+    timezone: AoE
+    utc: '2026-01-20T11:59:59Z'
+  - type: notification
+    label: Summary rejection notification
+    date: '2026-03-04 23:59:59'
+    timezone: AoE
+    utc: '2026-03-05T11:59:59Z'
+  - type: rebuttal_start
+    label: Author response period start
+    date: '2026-04-07 23:59:59'
+    timezone: AoE
+    utc: '2026-04-08T11:59:59Z'
+  - type: rebuttal_end
+    label: Author response period end
+    date: '2026-04-10 23:59:59'
+    timezone: AoE
+    utc: '2026-04-11T11:59:59Z'
+  - type: notification
+    label: Paper notification
+    date: '2026-04-29 23:59:59'
+    timezone: AoE
+    utc: '2026-04-30T11:59:59Z'
+  - type: camera_ready
+    label: Camera-ready deadline
+    date: '2026-05-15 23:59:59'
+    timezone: AoE
+    utc: '2026-05-16T11:59:59Z'
+  source: ai-deadlines
+  full_name: European Conference on Artificial Intelligence
+  link: https://2026.ijcai.org/
+  place: Bremen, Germany
+  date: August 15-21, 2026
+  start: '2026-08-15'
+  end: '2026-08-21'
+  note: Joint conference with IJCAI 2026 (IJCAI-ECAI 2026). All important dates can be found <a href='https://2026.ijcai.org/important-dates/'>here</a>.
+- id: eccv26
+  title: ECCV
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - computer-vision
+  deadlines:
+  - type: submission
+    label: Tutorial Proposal Submission
+    date: '2026-02-15 23:59:59'
+    timezone: AoE
+    utc: '2026-02-16T11:59:59Z'
+  - type: registration
+    label: Paper Registration
+    date: '2026-02-26 22:00:00'
+    timezone: UTC
+    utc: '2026-02-26T22:00:00Z'
+  - type: submission
+    label: Workshop Proposal Submission
+    date: '2026-02-27 23:59:59'
+    timezone: AoE
+    utc: '2026-02-28T11:59:59Z'
+  - type: paper
+    label: Paper Submission
+    date: '2026-03-05 22:00:00'
+    timezone: UTC
+    utc: '2026-03-05T22:00:00Z'
+  - type: supplementary
+    label: Supplemental Materials
+    date: '2026-03-12 22:00:00'
+    timezone: UTC
+    utc: '2026-03-12T22:00:00Z'
+  - type: notification
+    label: Tutorial/Workshop Decisions
+    date: '2026-04-12 20:00:00'
+    timezone: UTC
+    utc: '2026-04-12T20:00:00Z'
+  - type: review_release
+    label: Reviews Released to Authors
+    date: '2026-05-02 23:59:59'
+    timezone: UTC
+    utc: '2026-05-02T23:59:59Z'
+  - type: rebuttal_end
+    label: Rebuttal Deadline
+    date: '2026-05-11 21:00:00'
+    timezone: UTC
+    utc: '2026-05-11T21:00:00Z'
+  - type: submission
+    label: AI Art Submission
+    date: '2026-06-14 23:59:59'
+    timezone: AoE
+    utc: '2026-06-15T11:59:59Z'
+  - type: notification
+    label: Final Decisions
+    date: '2026-06-17 23:59:59'
+    timezone: UTC
+    utc: '2026-06-17T23:59:59Z'
+  - type: camera_ready
+    label: Camera Ready Deadline
+    date: '2026-06-26 23:59:59'
+    timezone: AoE
+    utc: '2026-06-27T11:59:59Z'
+  - type: notification
+    label: AI Art Acceptance Notification
+    date: '2026-06-29 23:59:59'
+    timezone: AoE
+    utc: '2026-06-30T11:59:59Z'
+  source: ai-deadlines
+  full_name: European Conference on Computer Vision
+  link: https://eccv.ecva.net/Conferences/2026
+  place: Malmö, Sweden
+  date: September 8-12, 2026
+  start: '2026-09-08'
+  end: '2026-09-12'
+- id: ecir27
+  title: ECIR
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - data-mining
+  deadlines: []
+  source: ai-deadlines
+  full_name: European Conference on Information Retrieval
+  link: https://www.ecir2027.co.uk/
+  place: Southampton, United Kingdom
+  date: March 21 - March 25, 2027
+  start: '2027-03-21'
+  end: '2027-03-25'
+  note: More info <a href='https://www.ecir2027.co.uk/'>here</a>. Submission deadlines TBA.
+- id: ecmlpkdd26
+  title: ECML PKDD
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - data-mining
+  - machine-learning
+  deadlines:
+  - type: abstract
+    label: Abstract submission (Research Track)
+    date: '2026-03-05 23:59:59'
+    timezone: AoE
+    utc: '2026-03-06T11:59:59Z'
+  - type: paper
+    label: Paper submission (Research Track)
+    date: '2026-03-12 23:59:59'
+    timezone: AoE
+    utc: '2026-03-13T11:59:59Z'
+  - type: notification
+    label: Author notification
+    date: '2026-05-27 23:59:59'
+    timezone: AoE
+    utc: '2026-05-28T11:59:59Z'
+  - type: camera_ready
+    label: Camera ready submission
+    date: '2026-06-18 23:59:59'
+    timezone: AoE
+    utc: '2026-06-19T11:59:59Z'
+  source: ai-deadlines
+  full_name: European Conference on Machine Learning and Principles and Practice of Knowledge Discovery
+    in Databases
+  link: https://ecmlpkdd.org/2026/
+  place: Naples, Italy
+  date: September 7 - 11, 2026
+  start: '2026-09-07'
+  end: '2026-09-11'
+- id: emnlp26sys
+  title: EMNLP (System Demonstrations Track)
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - natural-language-processing
+  deadlines: []
+  source: ai-deadlines
+  full_name: The annual Conference on Empirical Methods in Natural Language Processing (System Demonstrations
+    Track)
+  link: https://2026.emnlp.org/
+  place: Budapest, Hungary
+  date: October 24-29, 2026
+  start: '2026-10-24'
+  end: '2026-10-29'
+- id: euvip26
+  title: EUVIP
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - computer-vision
+  - deep-learning
+  - image-processing
+  - machine-learning
+  - signal-processing
+  - visual-information-processing
+  deadlines:
+  - type: submission
+    label: Paper submission deadline
+    date: '2026-06-05 23:59:59'
+    timezone: UTC+02
+    utc: '2026-06-05T21:59:59Z'
+  - type: notification
+    label: Notification of acceptance
+    date: '2026-07-18 23:59:59'
+    timezone: UTC+02
+    utc: '2026-07-18T21:59:59Z'
+  - type: camera_ready
+    label: Camera-ready submission deadline
+    date: '2026-07-25 23:59:59'
+    timezone: UTC+02
+    utc: '2026-07-25T21:59:59Z'
+  source: ai-deadlines
+  full_name: European Conference on Visual Information Processing
+  link: https://euvip2026.github.io/
+  place: Luxembourg, Luxembourg
+  date: September 28 - October 1, 2026
+  start: '2026-09-28'
+  end: '2026-10-01'
+  note: To check other calls (e.g., Tutorials, Special Sessions, etc.), please visit https://euvip2026.github.io/calls/
+- id: eurosys27spring
+  title: EuroSys (Spring)
+  year: 2027
+  areas:
+  - Systems
+  tags:
+  - systems
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2026-05-07 23:59:59'
+    timezone: UTC-12
+    utc: '2026-05-08T11:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2026-05-14 23:59:59'
+    timezone: UTC-12
+    utc: '2026-05-15T11:59:59Z'
+  source: casys
+  link: https://2027.eurosys.org/cfp.html
+  place: Rabat, Morocco
+  date: April 19-24, 2027
+  start: '2027-04-19'
+  end: '2027-04-24'
+- id: hicss27
+  title: HICSS
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - information-systems
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-06-15 23:59:59'
+    timezone: Pacific/Honolulu
+    utc: '2026-06-16T09:59:59Z'
+  source: ai-deadlines
+  full_name: Hawaii International Conference on System Sciences
+  link: https://hicss.hawaii.edu/
+  place: Waikoloa, USA
+  date: January 5-8, 2027
+  note: Paper submission deadline on June 15th, 2026 at 11:59 PM HST. Conference held January 5-8, 2027
+    at Hilton Waikoloa Village, Big Island, Hawaii.
+- id: hpca27
+  title: HPCA
+  year: 2027
+  areas:
+  - Systems
+  tags:
+  - computer-architecture
+  - systems
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2026-07-24 23:59:59'
+    timezone: AoE
+    utc: '2026-07-25T11:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2026-07-31 23:59:59'
+    timezone: AoE
+    utc: '2026-08-01T11:59:59Z'
+  source: casys
+  link: https://conf.researchr.org/home/hpca-2027
+  place: Salt Lake City, Utah, USA
+  date: March 20-24, 2027
+  start: '2027-03-20'
+  end: '2027-03-24'
+- id: hotnets26
+  title: HotNets
+  year: 2026
+  areas:
+  - Systems
+  tags:
+  - systems
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-07-16 23:59:59'
+    timezone: AoE
+    utc: '2026-07-17T11:59:59Z'
+  source: casys
+  full_name: ACM Workshop on Hot Topics in Networks
+  link: https://conferences.sigcomm.org/hotnets/2026/
+  place: Salt Lake City, UT, USA
+  date: November 16-17, 2026
+  start: '2026-11-16'
+  end: '2026-11-17'
+- id: icann26
+  title: ICANN
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - machine-learning
+  deadlines:
+  - type: abstract
+    label: Abstract and Full Paper Submission
+    date: '2026-03-30 23:59:59'
+    timezone: AoE
+    utc: '2026-03-31T11:59:59Z'
+  - type: submission
+    label: Full Paper Submission
+    date: '2026-03-30 23:59:59'
+    timezone: AoE
+    utc: '2026-03-31T11:59:59Z'
+  - type: notification
+    label: Final Notification
+    date: '2026-05-29 23:59:59'
+    timezone: AoE
+    utc: '2026-05-30T11:59:59Z'
+  - type: camera_ready
+    label: Camera-ready Paper Upload
+    date: '2026-06-15 23:59:59'
+    timezone: AoE
+    utc: '2026-06-16T11:59:59Z'
+  - type: registration
+    label: Author Registration and Early Registration
+    date: '2026-06-29 23:59:59'
+    timezone: AoE
+    utc: '2026-06-30T11:59:59Z'
+  source: ai-deadlines
+  full_name: 35th International Conference on Artificial Neural Networks
+  link: https://e-nns.org/icann2026/
+  place: Padua, Italy
+  date: September 14-17, 2026
+  start: '2026-09-14'
+  end: '2026-09-17'
+  note: Paper submission deadline extended to 30th March 2026. More info <a href='https://e-nns.org/icann2026/call-for-papers-2/'>here</a>.
+  hindex: 32.0
+- id: ICCD26
+  title: ICCD
+  year: 2026
+  areas:
+  - Systems
+  tags:
+  - computer-architecture
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2026-06-03 23:59:59'
+    timezone: AoE
+    utc: '2026-06-04T11:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2026-06-10 23:59:59'
+    timezone: AoE
+    utc: '2026-06-11T11:59:59Z'
+  source: casys
+  link: https://www.iccd-conf.com/
+  place: Hong Kong
+  date: November 16-18, 2026
+  start: '2026-11-16'
+  end: '2026-11-18'
+- id: icdar2026
+  title: ICDAR
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - computer-vision
+  deadlines:
+  - type: abstract
+    label: Abstract submission
+    date: '2026-02-13 23:59:59'
+    timezone: AoE
+    utc: '2026-02-14T11:59:59Z'
+  - type: paper
+    label: Paper submission
+    date: '2026-02-27 23:59:59'
+    timezone: AoE
+    utc: '2026-02-28T11:59:59Z'
+  - type: review_release
+    label: Reviews released
+    date: '2026-04-17 23:59:59'
+    timezone: AoE
+    utc: '2026-04-18T11:59:59Z'
+  - type: rebuttal_end
+    label: Rebuttal period ends
+    date: '2026-04-24 23:59:59'
+    timezone: AoE
+    utc: '2026-04-25T11:59:59Z'
+  - type: notification
+    label: Acceptance notification
+    date: '2026-05-15 23:59:59'
+    timezone: AoE
+    utc: '2026-05-16T11:59:59Z'
+  - type: camera_ready
+    label: Camera-ready deadline
+    date: '2026-06-15 23:59:59'
+    timezone: AoE
+    utc: '2026-06-16T11:59:59Z'
+  source: ai-deadlines
+  full_name: International Conference on Document Analysis and Recognition
+  link: https://icdar2026.org/
+  place: Vienna, Austria
+  date: August 30 - September 4, 2026
+  start: '2026-08-30'
+  end: '2026-09-04'
+- id: icdar2027
+  title: ICDAR
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - computer-vision
+  deadlines: []
+  source: ai-deadlines
+  full_name: International Conference on Document Analysis and Recognition
+  link: https://icdar2027.org/
+  place: Kuala Lumpur, Malaysia
+  date: August 18-22, 2027
+  start: '2027-08-18'
+  end: '2027-08-22'
+- id: icomp26
+  title: ICOMP
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - machine-learning
+  - optimization-methods
+  deadlines: []
+  source: ai-deadlines
+  full_name: International Conference on Computational Optimization
+  link: https://icomp.cc/
+  place: Yerevan, Armenia
+  date: September 11-13, 2026
+  start: '2026-09-11'
+  end: '2026-09-13'
+- id: icra27
+  title: ICRA
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - computer-vision
+  - robotics
+  deadlines: []
+  source: ai-deadlines
+  full_name: IEEE International Conference on Robotics and Automation
+  link: https://www.ieee-ras.org/conferences-workshops/fully-sponsored/icra/
+  place: Seoul, South Korea
+  date: May 24 - 28, 2027
+  start: '2027-05-24'
+  end: '2027-05-28'
+- id: IISWC26
+  title: IISWC
+  year: 2026
+  areas:
+  - Systems
+  tags:
+  - systems
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-05-21 23:59:59'
+    timezone: AoE
+    utc: '2026-05-22T11:59:59Z'
+  source: casys
+  link: https://iiswc.org/iiswc2026/cfp.html
+  place: Boulder, CO, USA
+  date: September 27-29, 2026
+  start: '2026-09-27'
+  end: '2026-09-29'
+- id: ijcai26
+  title: IJCAI
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - machine-learning
+  deadlines:
+  - type: abstract
+    label: Abstract submission deadline
+    date: '2026-01-12 23:59:59'
+    timezone: AoE
+    utc: '2026-01-13T11:59:59Z'
+  - type: paper
+    label: Full paper submission deadline
+    date: '2026-01-19 23:59:59'
+    timezone: AoE
+    utc: '2026-01-20T11:59:59Z'
+  - type: notification
+    label: Phase I notification
+    date: '2026-03-04 23:59:59'
+    timezone: AoE
+    utc: '2026-03-05T11:59:59Z'
+  - type: rebuttal_start
+    label: Author response period start
+    date: '2026-04-07 00:00:00'
+    timezone: AoE
+    utc: '2026-04-07T12:00:00Z'
+  - type: rebuttal_end
+    label: Author response period end
+    date: '2026-04-10 23:59:59'
+    timezone: AoE
+    utc: '2026-04-11T11:59:59Z'
+  - type: notification
+    label: Paper notification
+    date: '2026-04-29 23:59:59'
+    timezone: AoE
+    utc: '2026-04-30T11:59:59Z'
+  - type: camera_ready
+    label: Camera ready deadline
+    date: '2026-05-15 23:59:59'
+    timezone: AoE
+    utc: '2026-05-16T11:59:59Z'
+  source: ai-deadlines
+  full_name: International Joint Conference on Artificial Intelligence
+  link: https://2026.ijcai.org/
+  place: Bremen, Germany
+  date: August 15-21, 2026
+  start: '2026-08-15'
+  end: '2026-08-21'
+- id: inlg2026
+  title: INLG
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - natural-language-processing
+  deadlines:
+  - type: submission
+    label: Direct submission
+    date: '2026-07-18 23:59:59'
+    timezone: AoE
+    utc: '2026-07-19T11:59:59Z'
+  - type: commitment_deadline
+    label: Pre-reviewed ARR commitment
+    date: '2026-08-05 23:59:59'
+    timezone: AoE
+    utc: '2026-08-06T11:59:59Z'
+  - type: notification
+    label: Author notification date
+    date: '2026-08-15 23:59:59'
+    timezone: AoE
+    utc: '2026-08-16T11:59:59Z'
+  source: ai-deadlines
+  full_name: International Conference on Natural Language Generation
+  link: https://2026.inlgmeeting.org/
+  place: Utrecht, Netherlands
+  date: October 17-21, 2026
+  start: '2026-10-17'
+  end: '2026-10-21'
+  note: Endorsed by the Special Interest Group for Natural Language Generation (SIGGEN) of the Association
+    for Computational Linguistics.
+- id: iros26
+  title: IROS
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - robotics
+  deadlines:
+  - type: paper
+    label: Paper submission deadline
+    date: '2026-03-02 23:59:59'
+    timezone: AoE
+    utc: '2026-03-03T11:59:59Z'
+  - type: paper
+    label: Paper video submission deadline
+    date: '2026-03-07 23:59:59'
+    timezone: AoE
+    utc: '2026-03-08T11:59:59Z'
+  - type: notification
+    label: Paper acceptance notification
+    date: '2026-06-16 23:59:59'
+    timezone: AoE
+    utc: '2026-06-17T11:59:59Z'
+  - type: camera_ready
+    label: Final paper submission deadline
+    date: '2026-07-10 23:59:59'
+    timezone: AoE
+    utc: '2026-07-11T11:59:59Z'
+  source: ai-deadlines
+  full_name: IEEE\RSJ International Conference on Intelligent Robots and Systems
+  link: https://2026.ieee-iros.org/
+  place: Pittsburgh, USA
+  date: September 27 - October 1, 2026
+  start: '2026-09-27'
+  end: '2026-10-01'
+- id: ISPASS26
+  title: ISPASS
+  year: 2026
+  areas:
+  - Systems
+  tags:
+  - computer-architecture
+  - systems
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2025-12-12 23:59:59'
+    timezone: UTC-12
+    utc: '2025-12-13T11:59:59Z'
+  source: casys
+  link: https://ispass.org/ispass2026/
+  place: Seoul, South Korea
+  date: April 26-28
+- id: interspeech2026
+  title: Interspeech
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - signal-processing
+  - speech
+  deadlines:
+  - type: submission
+    label: Paper submission deadline
+    date: '2026-02-25 23:59:59'
+    timezone: AoE
+    utc: '2026-02-26T11:59:59Z'
+  - type: supplementary
+    label: Paper update deadline
+    date: '2026-03-04 23:59:59'
+    timezone: AoE
+    utc: '2026-03-05T11:59:59Z'
+  - type: rebuttal_start
+    label: Rebuttal period start
+    date: '2026-04-24 23:59:59'
+    timezone: AoE
+    utc: '2026-04-25T11:59:59Z'
+  - type: rebuttal_end
+    label: Rebuttal period end
+    date: '2026-05-01 23:59:59'
+    timezone: AoE
+    utc: '2026-05-02T11:59:59Z'
+  - type: notification
+    label: Paper acceptance notification
+    date: '2026-06-05 23:59:59'
+    timezone: AoE
+    utc: '2026-06-06T11:59:59Z'
+  - type: camera_ready
+    label: Camera-ready paper submission
+    date: '2026-06-19 23:59:59'
+    timezone: AoE
+    utc: '2026-06-20T11:59:59Z'
+  source: ai-deadlines
+  full_name: Interspeech
+  link: https://interspeech2026.org
+  place: Sydney, Australia
+  date: September 28-October 1, 2026
+  start: '2026-09-28'
+  end: '2026-10-01'
+- id: miccai26
+  title: MICCAI
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - computer-vision
+  deadlines:
+  - type: abstract
+    label: Abstract Submission
+    date: '2026-02-12 23:59:59'
+    timezone: UTC-08
+    utc: '2026-02-13T07:59:59Z'
+  - type: paper
+    label: Paper Submission
+    date: '2026-02-26 23:59:59'
+    timezone: UTC-08
+    utc: '2026-02-27T07:59:59Z'
+  - type: review_release
+    label: Early Acceptance & Reviews Released
+    date: '2026-05-07 23:59:59'
+    timezone: UTC-08
+    utc: '2026-05-08T07:59:59Z'
+  - type: rebuttal_start
+    label: Rebuttal Period Starts
+    date: '2026-05-08 23:59:59'
+    timezone: UTC-08
+    utc: '2026-05-09T07:59:59Z'
+  - type: rebuttal_end
+    label: Rebuttal Period Ends
+    date: '2026-05-14 23:59:59'
+    timezone: UTC-08
+    utc: '2026-05-15T07:59:59Z'
+  - type: camera_ready
+    label: Camera-Ready (Early Accepted Papers)
+    date: '2026-05-25 23:59:59'
+    timezone: UTC-08
+    utc: '2026-05-26T07:59:59Z'
+  - type: notification
+    label: Final Decisions
+    date: '2026-06-12 23:59:59'
+    timezone: UTC-08
+    utc: '2026-06-13T07:59:59Z'
+  - type: camera_ready
+    label: Camera-Ready (All Other Papers)
+    date: '2026-06-26 23:59:59'
+    timezone: UTC-08
+    utc: '2026-06-27T07:59:59Z'
+  source: ai-deadlines
+  full_name: International Conference on Medical Image Computing and Computer-Assisted Intervention
+  link: https://conferences.miccai.org/2026/
+  place: Strasbourg, France
+  date: September 27 - October 1, 2026
+  start: '2026-09-27'
+  end: '2026-10-01'
+  hindex: 98
+- id: micro26
+  title: MICRO
+  year: 2026
+  areas:
+  - Systems
+  tags:
+  - computer-architecture
+  - systems
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-04-07 23:59:59'
+    timezone: UTC-4
+    utc: '2026-04-08T03:59:59Z'
+  source: casys
+  link: https://microarch.org/micro59/index.php
+  place: Athens, Greece
+  date: October 31 – November 4, 2026
+- id: NSDI27spring
+  title: NSDI (Spring)
+  year: 2027
+  areas:
+  - Systems
+  tags:
+  - systems
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2026-04-16 23:59:59'
+    timezone: UTC-4
+    utc: '2026-04-17T03:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2026-04-23 23:59:59'
+    timezone: UTC-4
+    utc: '2026-04-24T03:59:59Z'
+  source: casys
+  link: https://www.usenix.org/conference/nsdi27/call-for-papers
+  place: Providence, RI, USA
+  date: May 11-13, 2027
+  start: '2027-05-11'
+  end: '2027-05-13'
+- id: pact26
+  title: PACT
+  year: 2026
+  areas:
+  - Systems
+  tags:
+  - computer-architecture
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-04-30 23:59:59'
+    timezone: AoE
+    utc: '2026-05-01T11:59:59Z'
+  source: casys
+  link: https://pact2026.github.io/submit
+  place: Chicago, IL, USA
+  date: October 19-22, 2026
+- id: rlc26
+  title: RLC
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - machine-learning
+  - reinforcement-learning
+  deadlines:
+  - type: abstract
+    label: Abstract submission
+    date: '2026-03-01 23:59:59'
+    timezone: AoE
+    utc: '2026-03-02T11:59:59Z'
+  - type: paper
+    label: Paper submission
+    date: '2026-03-05 23:59:59'
+    timezone: AoE
+    utc: '2026-03-06T11:59:59Z'
+  - type: notification
+    label: Author notification
+    date: '2026-05-08 23:59:59'
+    timezone: AoE
+    utc: '2026-05-09T11:59:59Z'
+  - type: camera_ready
+    label: Camera-ready deadline
+    date: '2026-07-18 23:59:59'
+    timezone: AoE
+    utc: '2026-07-19T11:59:59Z'
+  source: ai-deadlines
+  full_name: Reinforcement Learning Conference
+  link: https://rl-conference.cc/
+  place: Montreal, Canada
+  date: August 15 - 18, 2026
+  start: '2026-08-15'
+  end: '2026-08-18'
+  note: Mandatory abstract deadline on Mar 1, 2026.
+- id: rulemlrr26
+  title: RuleML+RR
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - knowledge-representation
+  - machine-learning
+  - reasoning
+  deadlines:
+  - type: abstract
+    label: Title and Abstract Submission (AoE)
+    date: '2026-05-08 23:59:59'
+    timezone: AoE
+    utc: '2026-05-09T11:59:59Z'
+  - type: submission
+    label: Paper Submission (AoE)
+    date: '2026-05-15 23:59:59'
+    timezone: AoE
+    utc: '2026-05-16T11:59:59Z'
+  - type: notification
+    label: Author notification
+    date: '2026-06-26 23:59:59'
+    timezone: AoE
+    utc: '2026-06-27T11:59:59Z'
+  source: ai-deadlines
+  full_name: International Joint Conference on Rules and Reasoning
+  link: https://2026.declarativeai.net/events/ruleml-rr
+  place: Vilnius, Lithuania
+  date: August 24–26, 2026
+  start: '2026-08-24'
+  end: '2026-08-26'
+  note: 'Part of "Declarative AI: Rules, Reasoning, Decisions, and Explanations". Proceedings published
+    by Springer LNCS. Long papers: up to 15 pages (excluding references) + 2 pages for references; Short
+    papers: up to 8 pages (excluding references) + 1 page for references. Notification: June 26, 2026
+    (AoE).'
+- id: sc26
+  title: SC
+  year: 2026
+  areas:
+  - Systems
+  tags:
+  - computer-architecture
+  - systems
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-04-08 23:59:59'
+    timezone: AoE
+    utc: '2026-04-09T11:59:59Z'
+  source: casys
+  link: https://sc26.supercomputing.org/all-dates-deadlines/
+  place: Chicago, IL, USA
+  date: November 15-20, 2026
+  start: '2026-11-15'
+  end: '2026-11-20'
+- id: sibgrapi26
+  title: SIBGRAPI
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - computer-graphics
+  - computer-vision
+  - image-processing
+  - pattern-recognition
+  deadlines:
+  - type: paper
+    label: Paper submission deadline
+    date: '2026-05-30 23:59:59'
+    timezone: UTC
+    utc: '2026-05-30T23:59:59Z'
+  - type: first-notification
+    label: First notification
+    date: '2026-07-07 23:59:59'
+    timezone: UTC
+    utc: '2026-07-07T23:59:59Z'
+  - type: revision-deadline
+    label: Revision submission deadline
+    date: '2026-07-18 23:59:59'
+    timezone: UTC
+    utc: '2026-07-18T23:59:59Z'
+  - type: final-notification
+    label: Final notification
+    date: '2026-08-03 23:59:59'
+    timezone: UTC
+    utc: '2026-08-03T23:59:59Z'
+  - type: camera-ready
+    label: Camera-ready version
+    date: '2026-08-15 23:59:59'
+    timezone: UTC
+    utc: '2026-08-15T23:59:59Z'
+  source: ai-deadlines
+  full_name: Conference on Graphics, Patterns and Images
+  link: https://sibgrapi.sbc.org.br/2026/
+  place: Goiânia, Brazil
+  date: September 29 to October 2, 2026
+  start: '2026-09-29'
+  end: '2026-10-02'
+  hindex: 22
+- id: siggraph27
+  title: SIGGRAPH
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - computer-graphics
+  deadlines: []
+  source: ai-deadlines
+  full_name: Conference on Computer Graphics and Interactive Techniques
+  link: https://www.siggraph.org/
+  place: Anaheim, United States
+  date: August 8-12, 2027
+  start: '2027-08-08'
+  end: '2027-08-12'
+- id: sosp26
+  title: SOSP
+  year: 2026
+  areas:
+  - Systems
+  tags:
+  - systems
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2026-03-26 23:59:59'
+    timezone: UTC-12
+    utc: '2026-03-27T11:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2026-04-01 23:59:59'
+    timezone: UTC-12
+    utc: '2026-04-02T11:59:59Z'
+  source: casys
+  link: https://sigops.org/s/conferences/sosp/2026/cfp.html
+  place: Prague, Czechia
+  date: September 29 - October 2, 2026
+  start: '2026-09-29'
+  end: '2026-10-02'
+- id: uai26
+  title: UAI
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - machine-learning
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-02-25 23:59:59'
+    timezone: AoE
+    utc: '2026-02-26T11:59:59Z'
+  source: ai-deadlines
+  full_name: Conference on Uncertainty in Artificial Intelligence
+  link: https://www.auai.org/uai2026/
+  place: Amsterdam, Netherlands
+  date: August 17-21, 2025
+  hindex: 50

--- a/_pages/deadlines.md
+++ b/_pages/deadlines.md
@@ -1,0 +1,324 @@
+---
+layout: page
+title: Deadlines
+permalink: /deadlines/
+description: AI 및 컴퓨터 시스템 분야 주요 학회의 논문 마감일을 모아 보여줍니다. 데이터는 매주 자동으로 갱신됩니다.
+nav: true
+nav_order: 6
+---
+
+<!-- pages/deadlines.md -->
+
+<style>
+.dl-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+  margin: 1.2rem 0 1.5rem;
+}
+
+.dl-filter {
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid var(--global-divider-color, #ddd);
+  background: var(--global-card-bg-color, #fff);
+  color: var(--global-text-color, #333);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.dl-filter:hover { border-color: var(--global-theme-color, #4285f4); }
+
+.dl-filter.active {
+  background: var(--global-theme-color, #4285f4);
+  border-color: var(--global-theme-color, #4285f4);
+  color: #fff;
+}
+
+#dl-search {
+  flex: 1 1 200px;
+  min-width: 160px;
+  padding: 0.4rem 0.8rem;
+  border-radius: 8px;
+  border: 1px solid var(--global-divider-color, #ddd);
+  background: var(--global-card-bg-color, #fff);
+  color: var(--global-text-color, #333);
+  font-size: 0.85rem;
+}
+
+.dl-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: var(--global-text-color-light, #666);
+  cursor: pointer;
+}
+
+.dl-card {
+  display: flex;
+  align-items: stretch;
+  gap: 1.2rem;
+  margin-bottom: 0.7rem;
+  padding: 1rem 1.2rem;
+  border-radius: 12px;
+  background: var(--global-card-bg-color, #fff);
+  border: 1px solid var(--global-divider-color, #f0f0f0);
+  transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+  color: var(--global-text-color);
+  text-decoration: none;
+}
+
+.dl-card:hover,
+.dl-card:focus {
+  box-shadow: 0 8px 25px rgba(0,0,0,0.08), 0 2px 10px rgba(0,0,0,0.04);
+  transform: translateY(-2px);
+  color: var(--global-text-color);
+  text-decoration: none;
+}
+
+.dl-count {
+  flex: 0 0 5.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  border-right: 1px solid var(--global-divider-color, #eee);
+  padding-right: 1rem;
+}
+
+.dl-dday {
+  font-size: 1.35rem;
+  font-weight: 700;
+  font-family: 'Roboto', monospace;
+  line-height: 1.1;
+  color: var(--global-theme-color, #4285f4);
+}
+
+.dl-dday.urgent { color: #d93025; }
+.dl-dday.closed { color: var(--global-text-color-light, #999); font-size: 1rem; }
+
+.dl-remain {
+  font-size: 0.7rem;
+  font-family: 'Roboto', monospace;
+  color: var(--global-text-color-light, #888);
+  margin-top: 0.2rem;
+}
+
+.dl-body { flex: 1 1 auto; min-width: 0; }
+
+.dl-title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin: 0 0 0.25rem;
+  color: var(--global-text-color);
+}
+
+.dl-card:hover .dl-title { color: var(--global-theme-color); }
+
+.dl-year {
+  font-family: 'Roboto', monospace;
+  color: var(--global-text-color-light, #888);
+  font-weight: 400;
+}
+
+.dl-badge {
+  display: inline-block;
+  font-size: 0.65rem;
+  font-weight: 600;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  margin-left: 0.35rem;
+  vertical-align: middle;
+}
+
+.dl-badge.area-AI { background: var(--global-theme-color, #4285f4); color: #fff; }
+.dl-badge.area-Systems { background: #34a853; color: #fff; }
+.dl-badge.area-Other { background: var(--global-divider-color, #e5e5e5); color: var(--global-text-color, #333); }
+.dl-badge.tba { background: #fbbc04; color: #333; }
+
+.dl-full {
+  font-size: 0.78rem;
+  color: var(--global-text-color-light, #777);
+  margin: 0 0 0.3rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dl-meta {
+  font-size: 0.75rem;
+  font-family: 'Roboto', monospace;
+  color: var(--global-text-color-light, #666);
+  margin: 0;
+}
+
+.dl-meta .sep { color: var(--global-divider-color, #ccc); margin: 0 0.45rem; }
+.dl-when { font-weight: 600; color: var(--global-text-color, #444); }
+
+.dl-empty {
+  padding: 2rem 0;
+  text-align: center;
+  color: var(--global-text-color-light, #888);
+  font-size: 0.9rem;
+}
+
+.dl-source {
+  margin-top: 2.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--global-divider-color, #eee);
+  font-size: 0.75rem;
+  color: var(--global-text-color-light, #888);
+}
+
+@media (max-width: 768px) {
+  .dl-card { flex-direction: column; gap: 0.6rem; }
+  .dl-count {
+    flex-direction: row;
+    gap: 0.5rem;
+    justify-content: flex-start;
+    border-right: none;
+    border-bottom: 1px solid var(--global-divider-color, #eee);
+    padding: 0 0 0.5rem;
+  }
+  .dl-full { white-space: normal; }
+}
+</style>
+
+<div class="dl-controls">
+  <button class="dl-filter active" data-area="all" type="button">전체</button>
+  <button class="dl-filter" data-area="AI" type="button">AI</button>
+  <button class="dl-filter" data-area="Systems" type="button">Systems</button>
+  <input type="search" id="dl-search" placeholder="학회 이름 검색 (예: NeurIPS, ISCA)" aria-label="학회 검색">
+  <label class="dl-toggle">
+    <input type="checkbox" id="dl-show-past"> 마감 지난 학회도 보기
+  </label>
+</div>
+
+<div id="dl-list">
+{%- assign conferences = site.data.conferences %}
+{%- for conf in conferences %}
+  {%- assign areas = conf.areas | join: " " %}
+  {%- assign haystack = conf.title | append: " " | append: conf.full_name | append: " " | append: conf.place | append: " " | append: conf.year | downcase %}
+  <a class="dl-card{% unless conf.next_deadline %} dl-past{% endunless %}"
+     href="{{ conf.link | default: '#' }}"
+     {% if conf.link %}target="_blank" rel="noopener"{% endif %}
+     data-areas="{{ areas }}"
+     data-search="{{ haystack | escape }}"
+     {% if conf.next_deadline %}data-deadline="{{ conf.next_deadline }}"{% endif %}>
+    <div class="dl-count">
+      <span class="dl-dday">{% if conf.next_deadline %}—{% else %}마감 종료{% endif %}</span>
+      {%- if conf.next_deadline %}<span class="dl-remain"></span>{% endif %}
+    </div>
+    <div class="dl-body">
+      <p class="dl-title">
+        {{ conf.title }} <span class="dl-year">{{ conf.year }}</span>
+        {%- for area in conf.areas %}<span class="dl-badge area-{{ area }}">{{ area }}</span>{% endfor %}
+        {%- if conf.tba %}<span class="dl-badge tba">CFP 미발표</span>{% endif %}
+      </p>
+      {%- if conf.full_name %}
+      <p class="dl-full">{{ conf.full_name }}</p>
+      {%- endif %}
+      <p class="dl-meta">
+        {%- if conf.next_deadline %}
+        <span class="dl-when" data-deadline="{{ conf.next_deadline }}"></span><span class="sep">|</span>
+        {%- endif %}
+        {%- if conf.date %}{{ conf.date }}{%- endif %}
+        {%- if conf.date and conf.place %}<span class="sep">|</span>{% endif %}
+        {%- if conf.place %}{{ conf.place }}{%- endif %}
+      </p>
+    </div>
+  </a>
+{%- endfor %}
+</div>
+
+<p class="dl-empty" id="dl-empty" hidden>조건에 맞는 학회가 없습니다.</p>
+
+<p class="dl-source">
+  데이터 출처:
+  <a href="https://github.com/huggingface/ai-deadlines" target="_blank" rel="noopener">huggingface/ai-deadlines</a> (MIT License),
+  <a href="https://github.com/casys-kaist/casys-kaist.github.io" target="_blank" rel="noopener">casys-kaist/casys-kaist.github.io</a>.
+  매주 자동으로 동기화되며, 실제 마감일은 반드시 각 학회 공식 홈페이지에서 확인하시기 바랍니다.
+</p>
+
+<script>
+(function () {
+  var MINUTE = 60000, HOUR = 3600000, DAY = 86400000;
+
+  function renderCountdowns() {
+    var now = Date.now();
+    document.querySelectorAll('.dl-card[data-deadline]').forEach(function (card) {
+      var target = new Date(card.getAttribute('data-deadline')).getTime();
+      var diff = target - now;
+      var dday = card.querySelector('.dl-dday');
+      var remain = card.querySelector('.dl-remain');
+
+      if (diff <= 0) {
+        dday.textContent = '마감 종료';
+        dday.classList.add('closed');
+        if (remain) remain.textContent = '';
+        card.classList.add('dl-past');
+        return;
+      }
+
+      var days = Math.floor(diff / DAY);
+      dday.textContent = 'D-' + days;
+      dday.classList.toggle('urgent', days <= 7);
+      if (remain) {
+        var hours = Math.floor((diff % DAY) / HOUR);
+        var mins = Math.floor((diff % HOUR) / MINUTE);
+        remain.textContent = hours + '시간 ' + mins + '분';
+      }
+    });
+  }
+
+  // 마감 시각은 동기화 시점에 UTC로 변환해 두었으므로, 여기서는 보는 사람의
+  // 현지 시간대로만 표시하면 된다.
+  function renderLocalTimes() {
+    document.querySelectorAll('.dl-when[data-deadline]').forEach(function (el) {
+      var d = new Date(el.getAttribute('data-deadline'));
+      el.textContent = d.toLocaleString(undefined, {
+        year: 'numeric', month: 'short', day: 'numeric',
+        hour: '2-digit', minute: '2-digit'
+      });
+      el.title = '내 시간대 기준 마감 시각';
+    });
+  }
+
+  function applyFilters() {
+    var area = document.querySelector('.dl-filter.active').getAttribute('data-area');
+    var query = document.getElementById('dl-search').value.trim().toLowerCase();
+    var showPast = document.getElementById('dl-show-past').checked;
+    var visible = 0;
+
+    document.querySelectorAll('.dl-card').forEach(function (card) {
+      var matchArea = area === 'all' || card.getAttribute('data-areas').indexOf(area) !== -1;
+      var matchQuery = !query || card.getAttribute('data-search').indexOf(query) !== -1;
+      var matchPast = showPast || !card.classList.contains('dl-past');
+      var show = matchArea && matchQuery && matchPast;
+      card.hidden = !show;
+      if (show) visible++;
+    });
+
+    document.getElementById('dl-empty').hidden = visible > 0;
+  }
+
+  document.querySelectorAll('.dl-filter').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      document.querySelectorAll('.dl-filter').forEach(function (b) { b.classList.remove('active'); });
+      btn.classList.add('active');
+      applyFilters();
+    });
+  });
+  document.getElementById('dl-search').addEventListener('input', applyFilters);
+  document.getElementById('dl-show-past').addEventListener('change', applyFilters);
+
+  renderCountdowns();
+  renderLocalTimes();
+  applyFilters();
+  setInterval(renderCountdowns, MINUTE);
+})();
+</script>

--- a/bin/sync_deadlines.py
+++ b/bin/sync_deadlines.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""학회 논문 마감일 데이터를 상류 저장소에서 가져와 _data/conferences.yml 로 동기화한다.
+
+상류 두 곳을 합친다.
+
+- huggingface/ai-deadlines            : AI 학회 (에이전트가 주기적으로 갱신)
+- casys-kaist/casys-kaist.github.io   : 컴퓨터 시스템/아키텍처 학회 (KAIST CASYS 관리)
+
+두 상류는 스키마가 다르므로 하나의 형태로 정규화하고, 마감 시각을 UTC로 미리
+변환해 둔다. 브라우저에서 타임존을 다시 계산할 필요 없이 Date 하나로 카운트다운
+할 수 있도록 하기 위함이다.
+
+사용법:
+
+    python3 bin/sync_deadlines.py                    # 상류를 임시 디렉터리에 clone
+    python3 bin/sync_deadlines.py --hf-dir DIR ...   # 이미 받아둔 clone 재사용
+"""
+
+import argparse
+import datetime as dt
+import glob
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from collections import defaultdict
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+import yaml
+
+HF_REPO = "https://github.com/huggingface/ai-deadlines"
+HF_DATA_PATH = "src/data/conferences"
+CASYS_REPO = "https://github.com/casys-kaist/casys-kaist.github.io"
+CASYS_DATA_PATH = "_data/conferences"
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+OUTPUT = os.path.join(REPO_ROOT, "_data", "conferences.yml")
+
+DATE_FORMATS = ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M", "%Y-%m-%d")
+TBA_WORDS = {"tba", "tbd", "n/a", "none", ""}
+
+# CASYS 의 sub 코드를 상위 분류로 매핑한다. HF 쪽은 전부 AI 로 본다.
+CASYS_AREA = {"ARCH": "Systems", "SYS": "Systems", "ML": "AI", "OTHER": "Other"}
+CASYS_TAG = {
+    "ARCH": "computer-architecture",
+    "SYS": "systems",
+    "ML": "machine-learning",
+    "OTHER": "other",
+}
+
+
+def sparse_clone(repo, data_path, dest):
+    """상류 저장소에서 데이터 디렉터리만 얇게 받아온다."""
+    subprocess.run(
+        ["git", "clone", "--depth", "1", "--filter=blob:none", "--sparse", repo, dest],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    subprocess.run(
+        ["git", "-C", dest, "sparse-checkout", "set", data_path],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return os.path.join(dest, data_path)
+
+
+def load_yaml_dir(path):
+    entries = []
+    for f in sorted(glob.glob(os.path.join(path, "*.yml"))):
+        with open(f, encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or []
+        if isinstance(data, list):
+            entries.extend(x for x in data if isinstance(x, dict))
+    return entries
+
+
+def resolve_timezone(tz):
+    """상류에서 쓰는 여러 타임존 표기를 tzinfo 로 변환한다."""
+    if not tz:
+        return dt.timezone.utc
+    tz = str(tz).strip()
+
+    # Anywhere on Earth = UTC-12. 가장 늦게 마감되는 기준시.
+    if tz.upper() == "AOE":
+        return dt.timezone(dt.timedelta(hours=-12))
+    fixed = {"PST": -8, "PDT": -7, "EST": -5, "EDT": -4, "CET": 1, "CEST": 2, "KST": 9}
+    if tz.upper() in fixed:
+        return dt.timezone(dt.timedelta(hours=fixed[tz.upper()]))
+
+    m = re.fullmatch(r"(?:UTC|GMT)\s*([+-])\s*(\d{1,2})(?::?(\d{2}))?", tz, re.I)
+    if m:
+        sign = 1 if m.group(1) == "+" else -1
+        hours, minutes = int(m.group(2)), int(m.group(3) or 0)
+        return dt.timezone(sign * dt.timedelta(hours=hours, minutes=minutes))
+    if tz.upper() in ("UTC", "GMT"):
+        return dt.timezone.utc
+
+    try:
+        return ZoneInfo(tz)
+    except (ZoneInfoNotFoundError, ValueError):
+        return dt.timezone.utc
+
+
+def to_utc(date_str, tz):
+    """'2026-08-28 11:00:00' + 타임존 → UTC ISO 문자열. 실패하면 None."""
+    if not date_str:
+        return None
+    s = str(date_str).strip().strip("'\"")
+    if s.lower() in TBA_WORDS:
+        return None
+    for fmt in DATE_FORMATS:
+        try:
+            naive = dt.datetime.strptime(s, fmt)
+            break
+        except ValueError:
+            continue
+    else:
+        return None
+    aware = naive.replace(tzinfo=resolve_timezone(tz))
+    return aware.astimezone(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def parse_day(value):
+    if not value:
+        return None
+    s = str(value).strip().strip("'\"")
+    try:
+        return dt.date.fromisoformat(s[:10])
+    except ValueError:
+        return None
+
+
+def normalize_tag(tag):
+    return re.sub(r"\s+", "-", str(tag).strip().lower())
+
+
+def base_title(title):
+    """'ASPLOS (Fall)' → 'ASPLOS'. 같은 학회의 여러 라운드를 묶기 위한 키."""
+    return re.sub(r"\s*\(.*?\)\s*", " ", str(title or "")).strip().upper()
+
+
+def round_label(title):
+    m = re.search(r"\((.*?)\)", str(title or ""))
+    return m.group(1).strip().lower() if m else ""
+
+
+def build_deadlines(entry, source):
+    """상류 두 스키마를 공통 deadlines 배열로 정규화한다."""
+    default_tz = entry.get("timezone")
+    out = []
+    seen = set()
+
+    for d in entry.get("deadlines") or []:
+        if not isinstance(d, dict):
+            continue
+        kind = str(d.get("type") or "submission")
+        utc = to_utc(d.get("date"), d.get("timezone") or default_tz)
+        out.append(
+            {
+                "type": kind,
+                "label": d.get("label") or kind.replace("_", " ").title(),
+                "date": str(d.get("date") or "").strip("'\""),
+                "timezone": d.get("timezone") or default_tz or "UTC",
+                "utc": utc,
+            }
+        )
+        seen.add(kind)
+
+    # CASYS 및 HF 구버전은 마감일이 평평한 필드로 들어 있다.
+    legacy = [
+        ("abstract", "Abstract Deadline", entry.get("abstract_deadline")),
+        ("submission", "Paper Submission", entry.get("deadline")),
+        ("commitment", "Commitment", entry.get("commitment_deadline")),
+    ]
+    for kind, label, value in legacy:
+        if kind in seen or not value:
+            continue
+        utc = to_utc(value, default_tz)
+        if utc is None:
+            continue
+        out.append(
+            {
+                "type": kind,
+                "label": label,
+                "date": str(value).strip("'\""),
+                "timezone": default_tz or "UTC",
+                "utc": utc,
+            }
+        )
+        seen.add(kind)
+
+    out = [d for d in out if d["utc"]]
+    out.sort(key=lambda d: d["utc"])
+    return out
+
+
+def normalize(entry, source):
+    title = str(entry.get("title") or "").strip()
+    year = entry.get("year")
+    if not title or not year:
+        return None
+
+    deadlines = build_deadlines(entry, source)
+
+    if source == "casys":
+        subs = entry.get("sub") or []
+        if isinstance(subs, str):
+            subs = [s.strip() for s in subs.split(",") if s.strip()]
+        subs = [str(s).strip().upper() for s in subs]
+        areas = sorted({CASYS_AREA[s] for s in subs if s in CASYS_AREA}) or ["Systems"]
+        tags = sorted({CASYS_TAG[s] for s in subs if s in CASYS_TAG})
+        tba = bool(entry.get("tba")) or "TBD" in subs
+        place = entry.get("place")
+    else:
+        areas = ["AI"]
+        tags = sorted({normalize_tag(t) for t in (entry.get("tags") or [])})
+        tba = bool(entry.get("tba"))
+        place = entry.get("place") or ", ".join(
+            x for x in (entry.get("city"), entry.get("country")) if x
+        )
+
+    record = {
+        "id": str(entry.get("id") or f"{base_title(title).lower()}{str(year)[-2:]}"),
+        "title": title,
+        "year": int(year),
+        "areas": areas,
+        "tags": tags,
+        "deadlines": deadlines,
+        "source": source,
+    }
+    for key, value in (
+        ("full_name", entry.get("full_name")),
+        ("link", entry.get("link")),
+        ("place", place),
+        ("date", entry.get("date")),
+        ("start", entry.get("start")),
+        ("end", entry.get("end")),
+        ("note", entry.get("note")),
+        ("hindex", entry.get("hindex")),
+    ):
+        if value not in (None, ""):
+            record[key] = str(value).strip("'\"") if key in ("start", "end") else value
+    if tba:
+        record["tba"] = True
+    return record
+
+
+def dedupe(records):
+    """두 상류에 함께 있는 학회를 정리한다.
+
+    같은 (학회, 연도)에 대해 라운드를 더 많이 관리하는 쪽을 채택한다.
+    ASPLOS 처럼 연 2~3회 마감이 있는 학회는 CASYS 가, 나머지는 대체로
+    자동 갱신되는 HF 가 더 정확하기 때문이다.
+    """
+    groups = defaultdict(lambda: defaultdict(list))
+    for r in records:
+        groups[(base_title(r["title"]), r["year"])][r["source"]].append(r)
+
+    merged = []
+    for buckets in groups.values():
+        hf, casys = buckets.get("ai-deadlines", []), buckets.get("casys", [])
+        if not hf:
+            chosen = casys
+        elif not casys:
+            chosen = hf
+        elif len(casys) > len(hf):
+            chosen = casys
+        elif len(hf) > len(casys):
+            chosen = hf
+        else:
+            # 1:1 이면 마감 정보가 더 충실한 쪽. 동률이면 HF.
+            chosen = hf if len(hf[0]["deadlines"]) >= len(casys[0]["deadlines"]) else casys
+
+        # 채택되지 않은 쪽의 분류는 살려 둔다 (예: ICML 은 AI 이면서 Systems 목록에도 있음).
+        others = [r for r in hf + casys if r not in chosen]
+        if others and len(chosen) == 1:
+            extra_areas = {a for r in others for a in r["areas"]}
+            chosen[0]["areas"] = sorted(set(chosen[0]["areas"]) | extra_areas)
+        merged.extend(chosen)
+    return merged
+
+
+def prune_and_sort(records, today):
+    """지난 학회는 버리고, 다가오는 마감 순으로 정렬한다."""
+    now = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    kept = []
+    for r in records:
+        upcoming = [d["utc"] for d in r["deadlines"] if d["utc"] > now]
+        end = parse_day(r.get("end")) or parse_day(r.get("start"))
+        if end is not None:
+            alive = end >= today
+        else:
+            # 개최 일정이 아직 공지되지 않은 학회는 연도로만 판단한다.
+            alive = r["year"] >= today.year
+        if not upcoming and not alive:
+            continue
+        if upcoming:
+            r["next_deadline"] = min(upcoming)
+        kept.append(r)
+
+    far_future = "9999"
+    kept.sort(key=lambda r: (r.get("next_deadline", far_future), r["title"], r["year"]))
+    return kept
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--hf-dir", help="이미 받아둔 ai-deadlines clone 경로")
+    ap.add_argument("--casys-dir", help="이미 받아둔 casys-kaist.github.io clone 경로")
+    ap.add_argument("--output", default=OUTPUT)
+    args = ap.parse_args()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        if args.hf_dir:
+            hf_path = os.path.join(args.hf_dir, HF_DATA_PATH)
+        else:
+            hf_path = sparse_clone(HF_REPO, HF_DATA_PATH, os.path.join(tmp, "hf"))
+        if args.casys_dir:
+            casys_path = os.path.join(args.casys_dir, CASYS_DATA_PATH)
+        else:
+            casys_path = sparse_clone(
+                CASYS_REPO, CASYS_DATA_PATH, os.path.join(tmp, "casys")
+            )
+
+        raw = [(e, "ai-deadlines") for e in load_yaml_dir(hf_path)]
+        raw += [(e, "casys") for e in load_yaml_dir(casys_path)]
+
+    records = [n for n in (normalize(e, s) for e, s in raw) if n]
+    records = dedupe(records)
+    records = prune_and_sort(records, dt.date.today())
+
+    if not records:
+        print("동기화 결과가 비어 있어 기존 파일을 유지한다.", file=sys.stderr)
+        return 1
+
+    header = (
+        "# 이 파일은 bin/sync_deadlines.py 가 생성한다. 직접 수정하지 말 것.\n"
+        "#\n"
+        "# 출처:\n"
+        f"#   - {HF_REPO} (MIT License)\n"
+        f"#   - {CASYS_REPO}\n"
+        "#\n"
+        "# 갱신: .github/workflows/sync-deadlines.yml 이 매주 실행하며,\n"
+        "#       수동 실행은 `python3 bin/sync_deadlines.py`.\n"
+    )
+    body = yaml.safe_dump(
+        records, allow_unicode=True, sort_keys=False, default_flow_style=False, width=100
+    )
+    with open(args.output, "w", encoding="utf-8") as fh:
+        fh.write(header + "\n" + body)
+
+    by_area = defaultdict(int)
+    for r in records:
+        for a in r["areas"]:
+            by_area[a] += 1
+    summary = ", ".join(f"{a} {n}건" for a, n in sorted(by_area.items()))
+    print(f"학회 {len(records)}건 기록 ({summary}) → {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 개요

AI 학회와 컴퓨터 시스템 학회의 논문 마감일을 모아 보여주는 **Deadlines** 메뉴를 추가하고, 데이터가 매주 자동으로 갱신되도록 합니다.

네비게이션에 `Deadlines` 탭이 추가되며(About / Members / Publications / Blog / Projects / Teaching / Photo / **Deadlines**), 페이지 주소는 `/deadlines/` 입니다.

## 데이터 수집 방식

상류 두 곳의 데이터를 합칩니다. 직접 크롤링하지 않고, 이미 잘 관리되는 목록을 가져다 쓰는 방식입니다.

| 상류 | 담당 범위 | 갱신 주체 |
|---|---|---|
| [huggingface/ai-deadlines](https://github.com/huggingface/ai-deadlines) (MIT) | AI 학회 | AI 에이전트가 웹 검색 후 PR |
| [casys-kaist/casys-kaist.github.io](https://github.com/casys-kaist/casys-kaist.github.io) | 시스템·아키텍처 학회 | KAIST CASYS 구성원 수동 관리 |

현재 **64건**(AI 39, Systems 25)이 반영되어 있습니다.

## `bin/sync_deadlines.py`

두 상류는 스키마가 달라(HF는 `deadlines[]` 배열, CASYS는 `deadline`/`abstract_deadline` 평면 필드) 하나의 형태로 정규화합니다. 주요 처리:

- **타임존 정규화** — `AoE`, `UTC±X`, `GMT±X`, IANA 이름(`Asia/Seoul`), `PST`/`EST` 등을 해석해 **마감 시각을 UTC로 미리 변환**해 둡니다. 덕분에 브라우저에서는 타임존 라이브러리 없이 `new Date()` 하나로 카운트다운이 됩니다.
- **중복 정리** — 같은 (학회, 연도)가 양쪽에 있으면 라운드를 더 많이 관리하는 쪽을 채택합니다. ASPLOS처럼 연 2~3회 마감이 있는 학회는 CASYS가, 나머지는 자동 갱신되는 HF가 더 정확하기 때문입니다. 채택되지 않은 쪽의 분야 분류는 살려 둡니다.
- **가지치기** — 이미 끝난 학회는 제외하고, 다가오는 마감 순으로 정렬합니다. 개최 일정이 아직 공지되지 않은 학회는 연도로 판단합니다.

## `_pages/deadlines.md`

- D-day 카운트다운 (7일 이내는 빨간색으로 강조)
- 분야 필터(전체 / AI / Systems), 학회명·장소 검색
- 기본적으로 **마감이 남은 학회만** 표시하고, 토글로 지난 것까지 볼 수 있습니다
- 마감 시각은 **보는 사람의 현지 시간대**로 표시합니다
- CFP 미발표 학회는 `CFP 미발표` 배지로 구분

## `.github/workflows/sync-deadlines.yml`

매주 월요일 05:00 KST(cron은 UTC 기준)에 동기화하고, 변경이 있으면 PR을 엽니다. 수동 실행(`workflow_dispatch`)도 가능합니다.

자동 커밋을 master에 직접 push하지 않고 PR을 여는 이유는, `GITHUB_TOKEN`으로 만든 push는 다른 워크플로를 트리거하지 않아 **데이터만 바뀌고 배포가 돌지 않기** 때문입니다. 사람이 머지하면 정상적으로 배포되고, 덤으로 이상한 데이터가 자동 반영되는 것도 막아줍니다.

## 검증

- 최신 master 기준으로 `jekyll build` 성공, `/deadlines/` 페이지 64개 카드 생성 및 네비게이션 `Deadlines` 탭 노출 확인
- 헤드리스 Chromium으로 실제 렌더링 확인: 카운트다운(D-0, D-1, D-4 …), 현지 시간 변환, 분야 필터(Systems 9건 / AI 11건), 검색, 지난 마감 토글(64건 전체 표시) 모두 정상 동작
- 동기화 스크립트를 CI와 동일한 경로(상류 자체 clone)로 실행했을 때 동일한 결과 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7TmYHkTXjYiyN5os9d2hb

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7TmYHkTXjYiyN5os9d2hb)_