### PR TITLE
QFlash (IJCAI 2026) 논문에 게재율 표기 추가

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -22,7 +22,7 @@ string{aps = {American Physical Society,}}
     abbr={IJCAI},
     title={QFlash: Bridging Quantization and Memory Efficiency in Vision Transformer Attention},
     author={Sehyeon Oh and Yongin Kwon and Jemin Lee*},
-    booktitle={International Joint Conferences on Artificial Intelligence (IJCAI) Aug. 15, 2026},
+    booktitle={International Joint Conferences on Artificial Intelligence (IJCAI) Aug. 15, 2026, Acceptance Rate <span class="label label-warning">13.6%</span> (713 papers accepted out of 5233 reviewed submissions).},
     pages={1-9},
     month = {8},
     year={2026},


### PR DESCRIPTION
## 개요

Publications 페이지의 QFlash 논문(IJCAI 2026)에 게재율을 추가합니다.

공식 발표 기준 **713편 채택 / 5233편 심사 = 13.6%** 입니다.

## 변경 내용

`_bibliography/papers.bib` 의 `oh26ijcai` 항목 `booktitle` 한 줄입니다.

```diff
- booktitle={International Joint Conferences on Artificial Intelligence (IJCAI) Aug. 15, 2026},
+ booktitle={International Joint Conferences on Artificial Intelligence (IJCAI) Aug. 15, 2026, Acceptance Rate <span class="label label-warning">13.6%</span> (713 papers accepted out of 5233 reviewed submissions).},
```

기존 학회 논문들과 같은 형식을 따랐습니다. 특히 작년 IJCAI 2025 논문(`Acceptance Rate 19.3% (1042 papers accepted out of 5404 submitted)`)과 동일한 구조라 두 항목이 나란히 일관되게 보입니다.

## 표기 관련

- **13.6%** 로 적었습니다. 713/5233 = 13.63% 이고, 기존 항목들이 모두 소수점 한 자리(19.3%, 28.2%, 57.1%, 6.4%)를 쓰고 있어 맞췄습니다.
- 분모는 "submitted" 가 아니라 **"reviewed submissions"** 로 적었습니다. 공식 발표 문구가 심사를 거친 편수 기준이라 그대로 옮겼습니다.

## 검증

`jekyll build` 후 `/publications/` 페이지에서 다음과 같이 렌더링되는 것을 확인했습니다.

> In International Joint Conferences on Artificial Intelligence (IJCAI) Aug. 15, 2026, Acceptance Rate **13.6%** (713 papers accepted out of 5233 reviewed submissions). , Aug 2026

`label label-warning` 배지도 정상 적용됩니다. About 페이지는 원래 게재율을 표시하지 않는 구조라 변화가 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7TmYHkTXjYiyN5os9d2hb

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7TmYHkTXjYiyN5os9d2hb)_