### PR TITLE
NLP 학회와 ARR 리뷰 사이클 일정을 deadlines 페이지에 추가

### DIFF
--- a/.github/workflows/sync-deadlines.yml
+++ b/.github/workflows/sync-deadlines.yml
@@ -1,6 +1,7 @@
 name: Sync conference deadlines
 
-# 상류 저장소의 학회 마감일 데이터를 주기적으로 가져와 _data/conferences.yml 을 갱신한다.
+# 상류 저장소(HF ai-deadlines, aideadlines.org, casys, IDSL)와 ACL Rolling Review
+# 일정을 주기적으로 가져와 _data/conferences.yml 을 갱신한다.
 # 변경이 있으면 PR 을 열고, 사람이 머지하면 deploy.yml 이 사이트를 다시 배포한다.
 # (자동 커밋을 master 로 직접 push 하면 GITHUB_TOKEN 으로 만든 push 는 다른
 #  워크플로를 트리거하지 않으므로 배포가 돌지 않는다.)

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -3,226 +3,6 @@
 # 갱신: .github/workflows/sync-deadlines.yml 이 매주 실행하며,
 #       수동 실행은 `python3 bin/sync_deadlines.py`.
 
-- id: cikm26
-  title: CIKM
-  year: 2026
-  areas:
-  - AI
-  tags:
-  - data-mining
-  - machine-learning
-  - web-search
-  deadlines:
-  - type: abstract
-    label: Abstract submission deadline
-    date: '2026-05-16 23:59:00'
-    timezone: AoE
-    utc: '2026-05-17T11:59:00Z'
-  - type: paper
-    label: Full paper submission deadline
-    date: '2026-05-23 23:59:00'
-    timezone: AoE
-    utc: '2026-05-24T11:59:00Z'
-  - type: notification
-    label: Author notification
-    date: '2026-08-07 23:59:00'
-    timezone: AoE
-    utc: '2026-08-08T11:59:00Z'
-  - type: camera_ready
-    label: Camera-ready deadline
-    date: '2026-08-20 23:59:00'
-    timezone: AoE
-    utc: '2026-08-21T11:59:00Z'
-  full_name: Conference on Information and Knowledge Management
-  link: https://cikm2026.diag.uniroma1.it/
-  place: Rome, Italy
-  date: November 7-11, 2026
-  start: '2026-11-07'
-  end: '2026-11-11'
-  note: All deadlines are at 11:59pm AoE
-  hindex: 91.0
-  next_deadline: '2026-08-21T11:59:00Z'
-- id: acm26
-  title: ACM MM
-  year: 2026
-  areas:
-  - AI
-  tags:
-  - computer-vision
-  - human-computer-interaction
-  - machine-learning
-  deadlines:
-  - type: abstract
-    label: Contribution registration
-    date: '2026-03-25 23:59:59'
-    timezone: AoE
-    utc: '2026-03-26T11:59:59Z'
-  - type: paper
-    label: Contribution submission
-    date: '2026-04-01 23:59:59'
-    timezone: AoE
-    utc: '2026-04-02T11:59:59Z'
-  - type: supplementary
-    label: Supplementary material submission
-    date: '2026-04-08 23:59:59'
-    timezone: AoE
-    utc: '2026-04-09T11:59:59Z'
-  - type: rebuttal_start
-    label: Rebuttal period start
-    date: '2026-06-04 23:59:59'
-    timezone: AoE
-    utc: '2026-06-05T11:59:59Z'
-  - type: notification
-    label: Author notification
-    date: '2026-07-09 23:59:59'
-    timezone: AoE
-    utc: '2026-07-10T11:59:59Z'
-  - type: camera_ready
-    label: Camera-ready submission
-    date: '2026-08-06 23:59:59'
-    timezone: AoE
-    utc: '2026-08-07T11:59:59Z'
-  - type: registration
-    label: Author registration
-    date: '2026-08-20 23:59:59'
-    timezone: AoE
-    utc: '2026-08-21T11:59:59Z'
-  full_name: ACM Multimedia
-  link: https://2026.acmmm.org/
-  place: Rio de Janeiro, Brazil
-  date: November 10-14, 2026
-  start: '2026-11-10'
-  end: '2026-11-14'
-  note: All important dates can be found <a href='https://2026.acmmm.org/site/important-dates.html'>here</a>.
-    The time for all dates is 23:59 AoE (Anywhere-on-Earth).
-  next_deadline: '2026-08-21T11:59:59Z'
-- id: emnlp26
-  title: EMNLP
-  year: 2026
-  areas:
-  - AI
-  tags:
-  - natural-language-processing
-  deadlines:
-  - type: paper
-    label: Paper submission deadline
-    date: '2026-05-25 23:59:59'
-    timezone: AoE
-    utc: '2026-05-26T11:59:59Z'
-  - type: reviewer_registration
-    label: Reviewer registration deadline
-    date: '2026-05-27 23:59:59'
-    timezone: AoE
-    utc: '2026-05-28T11:59:59Z'
-  - type: rebuttal_start
-    label: Author response period start
-    date: '2026-07-07 23:59:59'
-    timezone: AoE
-    utc: '2026-07-08T11:59:59Z'
-  - type: rebuttal_end
-    label: Author response period end
-    date: '2026-07-13 23:59:59'
-    timezone: AoE
-    utc: '2026-07-14T11:59:59Z'
-  - type: review_release
-    label: Meta review release
-    date: '2026-07-30 23:59:59'
-    timezone: AoE
-    utc: '2026-07-31T11:59:59Z'
-  - type: commitment_deadline
-    label: EMNLP commitment deadline
-    date: '2026-08-02 23:59:59'
-    timezone: AoE
-    utc: '2026-08-03T11:59:59Z'
-  - type: notification
-    label: Author notification date
-    date: '2026-08-20 23:59:59'
-    timezone: AoE
-    utc: '2026-08-21T11:59:59Z'
-  - type: camera_ready
-    label: Camera-ready deadline
-    date: '2026-08-30 23:59:59'
-    timezone: AoE
-    utc: '2026-08-31T11:59:59Z'
-  full_name: The annual Conference on Empirical Methods in Natural Language Processing
-  link: https://2026.emnlp.org/
-  place: Budapest, Hungary
-  date: October 24 - 29, 2026
-  start: '2026-10-24'
-  end: '2026-10-29'
-  next_deadline: '2026-08-21T11:59:59Z'
-- id: wacv27
-  title: WACV
-  year: 2027
-  areas:
-  - AI
-  tags:
-  - computer-vision
-  - machine-learning
-  deadlines:
-  - type: registration
-    label: Round 1 Paper Registration
-    date: '2026-06-19 23:59:59'
-    timezone: AoE
-    utc: '2026-06-20T11:59:59Z'
-  - type: submission
-    label: Round 1 Paper Submission
-    date: '2026-06-26 23:59:59'
-    timezone: AoE
-    utc: '2026-06-27T11:59:59Z'
-  - type: supplementary
-    label: Round 1 Supplementary Material
-    date: '2026-06-28 23:59:59'
-    timezone: AoE
-    utc: '2026-06-29T11:59:59Z'
-  - type: review_release
-    label: Round 1 Reviews and Decisions To Authors
-    date: '2026-08-09 23:59:59'
-    timezone: AoE
-    utc: '2026-08-10T11:59:59Z'
-  - type: rebuttal_and_revision
-    label: Round 1 Rebuttal and Revision Submission
-    date: '2026-08-21 23:59:59'
-    timezone: AoE
-    utc: '2026-08-22T11:59:59Z'
-  - type: registration
-    label: Round 2 New Paper Registration
-    date: '2026-08-21 23:59:59'
-    timezone: AoE
-    utc: '2026-08-22T11:59:59Z'
-  - type: submission
-    label: Round 2 Paper Submissions
-    date: '2026-08-28 23:59:59'
-    timezone: AoE
-    utc: '2026-08-29T11:59:59Z'
-  - type: supplementary
-    label: Round 2 Supplemental Material
-    date: '2026-08-30 23:59:59'
-    timezone: AoE
-    utc: '2026-08-31T11:59:59Z'
-  - type: notification
-    label: Round 2 Reviews and Final Decisions to Authors
-    date: '2026-10-09 23:59:59'
-    timezone: AoE
-    utc: '2026-10-10T11:59:59Z'
-  - type: notification
-    label: Round 1 Final Decisions Released to Authors
-    date: '2026-10-09 23:59:59'
-    timezone: AoE
-    utc: '2026-10-10T11:59:59Z'
-  - type: camera_ready
-    label: Camera Ready Both Rounds
-    date: '2026-11-02 23:59:59'
-    timezone: AoE
-    utc: '2026-11-03T11:59:59Z'
-  full_name: IEEE/CVF Winter Conference on Applications of Computer Vision
-  link: https://wacv.thecvf.com/
-  place: Buena Vista, FL, USA
-  date: January 4 - January 8, 2027
-  start: '2027-01-04'
-  end: '2027-01-08'
-  hindex: 131
-  next_deadline: '2026-08-22T11:59:59Z'
 - id: wsdm27
   title: WSDM
   year: 2027
@@ -300,6 +80,134 @@
   start: '2027-04-06'
   end: '2027-04-09'
   next_deadline: '2026-08-28T18:00:00Z'
+- id: wacv27
+  title: WACV
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - computer-vision
+  - machine-learning
+  deadlines:
+  - type: registration
+    label: Round 1 Paper Registration
+    date: '2026-06-19 23:59:59'
+    timezone: AoE
+    utc: '2026-06-20T11:59:59Z'
+  - type: submission
+    label: Round 1 Paper Submission
+    date: '2026-06-26 23:59:59'
+    timezone: AoE
+    utc: '2026-06-27T11:59:59Z'
+  - type: supplementary
+    label: Round 1 Supplementary Material
+    date: '2026-06-28 23:59:59'
+    timezone: AoE
+    utc: '2026-06-29T11:59:59Z'
+  - type: review_release
+    label: Round 1 Reviews and Decisions To Authors
+    date: '2026-08-09 23:59:59'
+    timezone: AoE
+    utc: '2026-08-10T11:59:59Z'
+  - type: rebuttal_and_revision
+    label: Round 1 Rebuttal and Revision Submission
+    date: '2026-08-21 23:59:59'
+    timezone: AoE
+    utc: '2026-08-22T11:59:59Z'
+  - type: registration
+    label: Round 2 New Paper Registration
+    date: '2026-08-21 23:59:59'
+    timezone: AoE
+    utc: '2026-08-22T11:59:59Z'
+  - type: submission
+    label: Round 2 Paper Submissions
+    date: '2026-08-28 23:59:59'
+    timezone: AoE
+    utc: '2026-08-29T11:59:59Z'
+  - type: supplementary
+    label: Round 2 Supplemental Material
+    date: '2026-08-30 23:59:59'
+    timezone: AoE
+    utc: '2026-08-31T11:59:59Z'
+  - type: notification
+    label: Round 2 Reviews and Final Decisions to Authors
+    date: '2026-10-09 23:59:59'
+    timezone: AoE
+    utc: '2026-10-10T11:59:59Z'
+  - type: notification
+    label: Round 1 Final Decisions Released to Authors
+    date: '2026-10-09 23:59:59'
+    timezone: AoE
+    utc: '2026-10-10T11:59:59Z'
+  - type: camera_ready
+    label: Camera Ready Both Rounds
+    date: '2026-11-02 23:59:59'
+    timezone: AoE
+    utc: '2026-11-03T11:59:59Z'
+  full_name: IEEE/CVF Winter Conference on Applications of Computer Vision
+  link: https://wacv.thecvf.com/
+  place: Buena Vista, FL, USA
+  date: January 4 - January 8, 2027
+  start: '2027-01-04'
+  end: '2027-01-08'
+  hindex: 131
+  next_deadline: '2026-08-29T11:59:59Z'
+- id: emnlp26
+  title: EMNLP
+  year: 2026
+  areas:
+  - AI
+  - NLP
+  tags:
+  - natural-language-processing
+  deadlines:
+  - type: paper
+    label: Paper submission deadline
+    date: '2026-05-25 23:59:59'
+    timezone: AoE
+    utc: '2026-05-26T11:59:59Z'
+  - type: reviewer_registration
+    label: Reviewer registration deadline
+    date: '2026-05-27 23:59:59'
+    timezone: AoE
+    utc: '2026-05-28T11:59:59Z'
+  - type: rebuttal_start
+    label: Author response period start
+    date: '2026-07-07 23:59:59'
+    timezone: AoE
+    utc: '2026-07-08T11:59:59Z'
+  - type: rebuttal_end
+    label: Author response period end
+    date: '2026-07-13 23:59:59'
+    timezone: AoE
+    utc: '2026-07-14T11:59:59Z'
+  - type: review_release
+    label: Meta review release
+    date: '2026-07-30 23:59:59'
+    timezone: AoE
+    utc: '2026-07-31T11:59:59Z'
+  - type: commitment_deadline
+    label: EMNLP commitment deadline
+    date: '2026-08-02 23:59:59'
+    timezone: AoE
+    utc: '2026-08-03T11:59:59Z'
+  - type: notification
+    label: Author notification date
+    date: '2026-08-20 23:59:59'
+    timezone: AoE
+    utc: '2026-08-21T11:59:59Z'
+  - type: camera_ready
+    label: Camera-ready deadline
+    date: '2026-08-30 23:59:59'
+    timezone: AoE
+    utc: '2026-08-31T11:59:59Z'
+  full_name: The annual Conference on Empirical Methods in Natural Language Processing
+  link: https://2026.emnlp.org/
+  place: Budapest, Hungary
+  date: October 24 - 29, 2026
+  start: '2026-10-24'
+  end: '2026-10-29'
+  next_deadline: '2026-08-31T11:59:59Z'
 - id: asplos27summer
   title: ASPLOS (September)
   year: 2027
@@ -404,6 +312,83 @@
   start: '2027-03-20'
   end: '2027-03-20'
   next_deadline: '2026-09-11T11:59:59Z'
+- id: chi2027
+  title: CHI
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - human-computer-interaction
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-09-11 11:59:59'
+    timezone: UTC
+    utc: '2026-09-11T11:59:59Z'
+  full_name: ACM Conference on Human Factors in Computing Systems
+  link: https://chi2027.acm.org/
+  start: '2027-05-10'
+  end: '2027-05-14'
+  next_deadline: '2026-09-11T11:59:59Z'
+- id: DATE27
+  title: DATE
+  year: 2027
+  areas:
+  - Systems
+  tags:
+  - computer-architecture
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2026-09-13 23:59:59'
+    timezone: AoE
+    utc: '2026-09-14T11:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2026-09-20 23:59:59'
+    timezone: AoE
+    utc: '2026-09-21T11:59:59Z'
+  link: https://www.date-conference.com/date-2027-call-papers
+  place: Dresden, Germany
+  date: March 22-24, 2027
+  start: '2027-03-22'
+  end: '2027-03-24'
+  next_deadline: '2026-09-14T11:59:59Z'
+- id: arr-august26
+  title: ARR (August 2026)
+  year: 2026
+  areas:
+  - AI
+  - NLP
+  tags:
+  - natural-language-processing
+  deadlines:
+  - type: submission
+    label: Submission
+    date: '2026-08-03 23:59:59'
+    timezone: AoE
+    utc: '2026-08-04T11:59:59Z'
+  - type: author_response
+    label: Author Response Start
+    date: '2026-09-14 23:59:59'
+    timezone: AoE
+    utc: '2026-09-15T11:59:59Z'
+  - type: meta_review
+    label: Meta-review Release
+    date: '2026-10-08 23:59:59'
+    timezone: AoE
+    utc: '2026-10-09T11:59:59Z'
+  - type: cycle_end
+    label: Cycle End
+    date: '2026-10-11 23:59:59'
+    timezone: AoE
+    utc: '2026-10-12T11:59:59Z'
+  full_name: ACL Rolling Review — August 2026 cycle
+  link: https://aclrollingreview.org/dates
+  date: Cycle ends October 11, 2026
+  start: '2026-10-11'
+  end: '2026-10-11'
+  next_deadline: '2026-09-15T11:59:59Z'
 - id: fast27
   title: FAST
   year: 2027
@@ -423,43 +408,45 @@
   start: '2027-02-23'
   end: '2027-02-25'
   next_deadline: '2026-09-16T06:59:59Z'
-- id: DATE27
-  title: DATE
+- id: icra2027
+  title: ICRA
   year: 2027
   areas:
-  - Systems
+  - AI
   tags:
-  - computer-architecture
+  - computer-vision
+  - machine-learning
+  - robotics
   deadlines:
   - type: submission
     label: Paper Submission
-    date: '2026-09-15 23:59:59'
-    timezone: UTC-12
+    date: '2026-09-16 11:59:59'
+    timezone: UTC
     utc: '2026-09-16T11:59:59Z'
-  link: https://www.date-conference.com/date-2027-call-papers
-  place: TBD
-  date: TBD
-  tba: true
+  full_name: IEEE International Conference on Robotics and Automation
+  link: https://2027.ieee-icra.org/
+  place: Seoul, South Korea
+  start: '2027-05-24'
+  end: '2027-05-28'
+  hindex: 122
   next_deadline: '2026-09-16T11:59:59Z'
-- id: icassp-2027
+- id: icassp2027
   title: ICASSP
   year: 2027
   areas:
   - AI
   tags:
-  - machine-learning
+  - signal-processing
   deadlines:
   - type: submission
     label: Paper Submission
-    date: '2026-09-16 23:59:59'
-    timezone: AoE
+    date: '2026-09-17 11:59:59'
+    timezone: UTC
     utc: '2026-09-17T11:59:59Z'
   full_name: IEEE International Conference on Acoustics, Speech, and Signal Processing
   link: https://2027.ieeeicassp.org/
-  place: Canada (Toronto)
-  date: May 16, 2027
   start: '2027-05-16'
-  end: '2027-05-16'
+  end: '2027-05-21'
   next_deadline: '2026-09-17T11:59:59Z'
 - id: eurosys27fall
   title: EuroSys (Fall)
@@ -485,6 +472,32 @@
   start: '2027-04-19'
   end: '2027-04-24'
   next_deadline: '2026-09-18T11:59:59Z'
+- id: iclr27
+  title: ICLR
+  year: 2027
+  areas:
+  - AI
+  - NLP
+  tags:
+  - machine-learning
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2026-09-18 23:59:59'
+    timezone: AoE
+    utc: '2026-09-19T11:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2026-09-25 23:59:59'
+    timezone: AoE
+    utc: '2026-09-26T11:59:59Z'
+  full_name: The Fifteenth International Conference on Learning Representations
+  link: https://www.iclr.cc/Conferences/2027/CallForPapers
+  place: San Francisco, CA, USA
+  date: April 26-30, 2027
+  start: '2027-04-26'
+  end: '2027-04-30'
+  next_deadline: '2026-09-19T11:59:59Z'
 - id: neurips26
   title: NeurIPS
   year: 2026
@@ -590,8 +603,55 @@
   start: '2027-05-10'
   end: '2027-05-14'
   next_deadline: '2026-09-25T23:59:59Z'
-- id: iclr-2027
-  title: ICLR
+- id: ecir2027
+  title: ECIR
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - data-mining
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2026-09-26 11:59:59'
+    timezone: UTC
+    utc: '2026-09-26T11:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2026-10-03 11:59:59'
+    timezone: UTC
+    utc: '2026-10-03T11:59:59Z'
+  full_name: European Conference on Information Retrieval
+  link: https://ecir2027.co.uk/
+  start: '2027-03-21'
+  end: '2027-03-25'
+  next_deadline: '2026-09-26T11:59:59Z'
+- id: aamas2027
+  title: AAMAS
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - machine-learning
+  - robotics
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2026-10-02 23:59:00'
+    timezone: UTC
+    utc: '2026-10-02T23:59:00Z'
+  - type: submission
+    label: Paper Submission
+    date: '2026-10-09 23:59:00'
+    timezone: UTC
+    utc: '2026-10-09T23:59:00Z'
+  full_name: International Conference on Autonomous Agents and Multiagent Systems
+  link: https://openreview.net/group?id=ifaamas.org/AAMAS/2027/Conference
+  start: '2027-05-03'
+  end: '2027-05-03'
+  next_deadline: '2026-10-02T23:59:00Z'
+- id: aistats2027
+  title: AISTATS
   year: 2027
   areas:
   - AI
@@ -599,17 +659,16 @@
   - machine-learning
   deadlines:
   - type: submission
-    label: Paper Submission
-    date: '2026-09-25 23:59:59'
-    timezone: AoE
-    utc: '2026-09-26T11:59:59Z'
-  full_name: International Conference on Learning Representations
-  link: https://iclr.cc/Conferences/2027
-  place: USA (California)
-  date: April 26, 2027
-  start: '2027-04-26'
-  end: '2027-04-26'
-  next_deadline: '2026-09-26T11:59:59Z'
+    label: 'From AISTATS 2026: Abstract deadline on 2025-09-25 23:59:59 UTC-12!'
+    date: '2026-10-03 11:59:59'
+    timezone: UTC
+    utc: '2026-10-03T11:59:59Z'
+  full_name: International Conference on Artificial Intelligence and Statistics
+  start: '2027-05-02'
+  end: '2027-05-07'
+  hindex: 101
+  approx: true
+  next_deadline: '2026-10-03T11:59:59Z'
 - id: fpga-2027
   title: FPGA
   year: 2027
@@ -630,11 +689,83 @@
   start: '2027-03-14'
   end: '2027-03-14'
   next_deadline: '2026-10-09T11:59:59Z'
-- id: coling-2027
-  title: COLING
+- id: fg2027
+  title: FG
   year: 2027
   areas:
   - AI
+  tags:
+  - computer-vision
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2026-10-10 11:59:59'
+    timezone: UTC
+    utc: '2026-10-10T11:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2026-10-17 11:59:59'
+    timezone: UTC
+    utc: '2026-10-17T11:59:59Z'
+  full_name: International Conference on Automatic Face and Gesture Recognition
+  link: https://fg2027.ieee-biometrics.org/
+  start: '2027-04-26'
+  end: '2027-04-30'
+  next_deadline: '2026-10-10T11:59:59Z'
+- id: eacl2027
+  title: EACL
+  year: 2027
+  areas:
+  - AI
+  - NLP
+  tags:
+  - natural-language-processing
+  deadlines:
+  - type: submission
+    label: 'ARR Submission; commitment deadline: 2026-10-11'
+    date: '2026-08-04 11:59:59'
+    timezone: UTC
+    utc: '2026-08-04T11:59:59Z'
+  - type: commitment
+    label: ARR Commitment
+    date: '2026-10-11 23:59:59'
+    timezone: AoE
+    utc: '2026-10-12T11:59:59Z'
+  full_name: The Annual Conference of the European Chapter of the Association for Computational Linguistics
+  link: https://2027.eacl.org/
+  start: '2027-03-09'
+  end: '2027-03-14'
+  hindex: 77
+  next_deadline: '2026-10-12T11:59:59Z'
+- id: www2027
+  title: WWW
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - machine-learning
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2026-10-12 11:59:59'
+    timezone: UTC
+    utc: '2026-10-12T11:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2026-10-19 11:59:59'
+    timezone: UTC
+    utc: '2026-10-19T11:59:59Z'
+  full_name: International World Wide Web Conferences
+  link: https://acmweb2027.org/
+  start: '2027-05-10'
+  end: '2027-05-14'
+  next_deadline: '2026-10-12T11:59:59Z'
+- id: acl27october
+  title: ACL (October ARR)
+  year: 2027
+  areas:
+  - AI
+  - NLP
   tags:
   - machine-learning
   deadlines:
@@ -643,18 +774,87 @@
     date: '2026-10-12 23:59:59'
     timezone: AoE
     utc: '2026-10-13T11:59:59Z'
-  full_name: International Conference on Computational Linguistics
+  full_name: The 65th Annual Meeting of the Association for Computational Linguistics
+  link: https://aclrollingreview.org/dates
+  place: Kyoto, Japan
+  date: August 17-22, 2027
+  start: '2027-08-17'
+  end: '2027-08-22'
+  next_deadline: '2026-10-13T11:59:59Z'
+- id: alt2027
+  title: ALT
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - machine-learning
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-10-13 11:59:59'
+    timezone: UTC
+    utc: '2026-10-13T11:59:59Z'
+  full_name: International Conference on Algorithmic Learning Theory
+  link: https://algorithmiclearningtheory.org/alt2027/
+  start: '2027-03-09'
+  end: '2027-03-12'
+  next_deadline: '2026-10-13T11:59:59Z'
+- id: arr-october26
+  title: ARR (October 2026)
+  year: 2026
+  areas:
+  - AI
+  - NLP
+  tags:
+  - natural-language-processing
+  deadlines:
+  - type: submission
+    label: Submission
+    date: '2026-10-12 23:59:59'
+    timezone: AoE
+    utc: '2026-10-13T11:59:59Z'
+  - type: cycle_end
+    label: Cycle End
+    date: '2026-12-20 23:59:59'
+    timezone: AoE
+    utc: '2026-12-21T11:59:59Z'
+  full_name: ACL Rolling Review — October 2026 cycle
+  link: https://aclrollingreview.org/dates
+  date: Cycle ends December 20, 2026
+  start: '2026-12-20'
+  end: '2026-12-20'
+  next_deadline: '2026-10-13T11:59:59Z'
+- id: coling2027
+  title: COLING
+  year: 2027
+  areas:
+  - AI
+  - NLP
+  tags:
+  - natural-language-processing
+  deadlines:
+  - type: submission
+    label: ARR Submission
+    date: '2026-10-13 11:59:59'
+    timezone: UTC
+    utc: '2026-10-13T11:59:59Z'
+  - type: commitment
+    label: ARR Commitment
+    date: '2026-12-20 23:59:59'
+    timezone: AoE
+    utc: '2026-12-21T11:59:59Z'
+  full_name: INTERNATIONNAL CONFERENCE ON COMPUTATIONAL LINGUISTICS
   link: https://2027.coling-iccl.org/
-  place: China (Macau)
-  date: May 09, 2027
   start: '2027-05-09'
-  end: '2027-05-09'
+  end: '2027-05-14'
+  hindex: 81
   next_deadline: '2026-10-13T11:59:59Z'
 - id: naacl27
   title: NAACL
   year: 2027
   areas:
   - AI
+  - NLP
   tags:
   - natural-language-processing
   deadlines:
@@ -663,6 +863,11 @@
     date: '2026-10-12 23:59:59'
     timezone: AoE
     utc: '2026-10-13T11:59:59Z'
+  - type: commitment
+    label: ARR Commitment
+    date: '2026-12-20 23:59:59'
+    timezone: AoE
+    utc: '2026-12-21T11:59:59Z'
   full_name: The Annual Conference of the Nations of the Americas Chapter of the Association for Computational
     Linguistics
   link: https://2027.naacl.org/
@@ -712,6 +917,24 @@
   date: TBD
   tba: true
   next_deadline: '2026-10-30T19:59:59Z'
+- id: robosoft2027
+  title: RoboSoft
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - robotics
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-10-30 23:59:59'
+    timezone: UTC
+    utc: '2026-10-30T23:59:59Z'
+  link: https://www.robosoft27.org
+  place: Kanazawa, Japan
+  start: '2027-04-05'
+  end: '2027-04-09'
+  next_deadline: '2026-10-30T23:59:59Z'
 - id: isca27
   title: ISCA
   year: 2027
@@ -744,13 +967,32 @@
     date: '2026-11-18 16:59:59'
     timezone: UTC-7
     utc: '2026-11-18T23:59:59Z'
-  link: https://www.dac.com/Conference/2026-Call-for-Contributions
+  link: https://dac.com/events/dac-2027
   place: San Jose, CA, USA
   date: July 10-16, 2027
   start: '2027-07-10'
   end: '2027-07-16'
   tba: true
   next_deadline: '2026-11-18T23:59:59Z'
+- id: esann2027
+  title: ESANN
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - machine-learning
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-11-19 23:59:59'
+    timezone: UTC
+    utc: '2026-11-19T23:59:59Z'
+  full_name: European Symposium on Artificial Neural Networks, Computational Intelligence and Machine
+    Learning
+  start: '2027-04-22'
+  end: '2027-04-27'
+  approx: true
+  next_deadline: '2026-11-19T23:59:59Z'
 - id: osdi27
   title: OSDI
   year: 2027
@@ -759,18 +1001,197 @@
   tags:
   - systems
   deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2026-12-01 17:59:59'
+    timezone: UTC-5
+    utc: '2026-12-01T22:59:59Z'
   - type: submission
     label: Paper Submission
-    date: '2026-12-11 17:59:59'
+    date: '2026-12-08 17:59:59'
     timezone: UTC-5
-    utc: '2026-12-11T22:59:59Z'
-  link: https://www.usenix.org/conference/osdi27
+    utc: '2026-12-08T22:59:59Z'
+  link: https://www.usenix.org/conference/osdi27/call-for-papers
   place: Baltimore, MD, USA
   date: July 7-9, 2027
   start: '2027-07-07'
   end: '2027-07-09'
+  next_deadline: '2026-12-01T22:59:59Z'
+- id: icaps2027
+  title: ICAPS
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - robotics
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2026-12-02 23:59:59'
+    timezone: UTC
+    utc: '2026-12-02T23:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2026-12-08 23:59:59'
+    timezone: UTC
+    utc: '2026-12-08T23:59:59Z'
+  full_name: International Conference on Automated Planning and Scheduling
+  start: '2027-06-27'
+  end: '2027-07-02'
+  approx: true
+  next_deadline: '2026-12-02T23:59:59Z'
+- id: cpal2027
+  title: CPAL
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - machine-learning
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-12-05 23:59:59'
+    timezone: UTC
+    utc: '2026-12-05T23:59:59Z'
+  full_name: The Conference on Parsimony and Learning
+  start: '2027-03-23'
+  end: '2027-03-28'
+  approx: true
+  next_deadline: '2026-12-05T23:59:59Z'
+- id: acl27
+  title: ACL
+  year: 2027
+  areas:
+  - AI
+  - NLP
+  tags:
+  - machine-learning
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2027-01-05 23:59:59'
+    timezone: AoE
+    utc: '2027-01-06T11:59:59Z'
+  full_name: The 65th Annual Meeting of the Association for Computational Linguistics
+  link: https://2027.aclweb.org/
+  place: Kyoto, Japan
+  date: August 17-22, 2027
+  start: '2027-08-17'
+  end: '2027-08-22'
   tba: true
-  next_deadline: '2026-12-11T22:59:59Z'
+  next_deadline: '2027-01-06T11:59:59Z'
+- id: facct2027
+  title: FAccT
+  year: 2027
+  areas:
+  - AI
+  - NLP
+  tags:
+  - computer-vision
+  - machine-learning
+  - natural-language-processing
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2027-01-09 11:59:59'
+    timezone: UTC
+    utc: '2027-01-09T11:59:59Z'
+  - type: submission
+    label: 'From FAccT 2025: Paper Submission'
+    date: '2027-01-14 11:59:59'
+    timezone: UTC
+    utc: '2027-01-14T11:59:59Z'
+  full_name: ACM Conference on Fairness, Accountability, and Transparency
+  start: '2027-06-27'
+  end: '2027-07-02'
+  approx: true
+  next_deadline: '2027-01-09T11:59:59Z'
+- id: ijcai2027
+  title: IJCAI
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - machine-learning
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2027-01-12 23:59:59'
+    timezone: UTC
+    utc: '2027-01-12T23:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2027-01-19 23:59:59'
+    timezone: UTC
+    utc: '2027-01-19T23:59:59Z'
+  full_name: International Joint Conference on Artificial Intelligence
+  start: '2027-08-15'
+  end: '2027-08-20'
+  hindex: 136
+  approx: true
+  next_deadline: '2027-01-12T23:59:59Z'
+- id: ecai2027
+  title: ECAI
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - machine-learning
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2027-01-13 11:59:59'
+    timezone: UTC
+    utc: '2027-01-13T11:59:59Z'
+  - type: submission
+    label: 'From ECAI 2026: Full paper submission deadline'
+    date: '2027-01-20 11:59:59'
+    timezone: UTC
+    utc: '2027-01-20T11:59:59Z'
+  full_name: European Conference on Artificial Intelligence
+  start: '2027-08-15'
+  end: '2027-08-20'
+  approx: true
+  next_deadline: '2027-01-13T11:59:59Z'
+- id: ksem2027
+  title: KSEM
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - machine-learning
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2027-01-15 23:59:59'
+    timezone: UTC
+    utc: '2027-01-15T23:59:59Z'
+  full_name: International Conference on Knowledge Science, Engineering and Management
+  start: '2027-07-17'
+  end: '2027-07-22'
+  approx: true
+  next_deadline: '2027-01-15T23:59:59Z'
+- id: bis2027
+  title: BIS
+  year: 2027
+  areas:
+  - AI
+  - NLP
+  tags:
+  - data-mining
+  - machine-learning
+  - natural-language-processing
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2027-01-16 11:59:00'
+    timezone: UTC
+    utc: '2027-01-16T11:59:00Z'
+  full_name: International Conference on Business Information Systems
+  start: '2027-06-10'
+  end: '2027-06-15'
+  approx: true
+  next_deadline: '2027-01-16T11:59:00Z'
 - id: cec2027
   title: CEC
   year: 2027
@@ -791,8 +1212,149 @@
   start: '2027-07-25'
   end: '2027-07-28'
   next_deadline: '2027-01-16T11:59:59Z'
-- id: aaai-2027
-  title: AAAI
+- id: sigir2027
+  title: SIGIR
+  year: 2027
+  areas:
+  - AI
+  - NLP
+  tags:
+  - data-mining
+  - natural-language-processing
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2027-01-16 11:59:59'
+    timezone: UTC
+    utc: '2027-01-16T11:59:59Z'
+  - type: submission
+    label: 'From SIGIR 2026: Full research paper submission deadline'
+    date: '2027-01-23 11:59:59'
+    timezone: UTC
+    utc: '2027-01-23T11:59:59Z'
+  full_name: International ACM SIGIR Conference on Research and Development in Information Retrieval
+  start: '2027-07-20'
+  end: '2027-07-25'
+  approx: true
+  next_deadline: '2027-01-16T11:59:59Z'
+- id: gecco2027
+  title: GECCO
+  year: 2027
+  areas:
+  - AI
+  tags: []
+  deadlines:
+  - type: submission
+    label: 'From GECCO 2026: Poster-only papers'
+    date: '2026-01-26 23:59:00'
+    timezone: UTC
+    utc: '2026-01-26T23:59:00Z'
+  - type: abstract
+    label: Abstract Deadline
+    date: '2027-01-19 23:59:00'
+    timezone: UTC
+    utc: '2027-01-19T23:59:00Z'
+  - type: submission
+    label: 'From GECCO 2026: Full papers (traditional category)'
+    date: '2027-01-26 23:59:00'
+    timezone: UTC
+    utc: '2027-01-26T23:59:00Z'
+  full_name: Genetic and Evolutionary Computation Conference
+  start: '2027-07-13'
+  end: '2027-07-18'
+  approx: true
+  next_deadline: '2027-01-19T23:59:00Z'
+- id: icip2027
+  title: ICIP
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - computer-vision
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2027-01-21 23:59:59'
+    timezone: UTC
+    utc: '2027-01-21T23:59:59Z'
+  full_name: The IEEE International Conference on Image Processing
+  start: '2027-09-13'
+  end: '2027-09-18'
+  hindex: 55
+  approx: true
+  next_deadline: '2027-01-21T23:59:59Z'
+- id: gecco2028
+  title: GECCO
+  year: 2028
+  areas:
+  - AI
+  tags: []
+  deadlines:
+  - type: submission
+    label: 'From GECCO 2026: Poster-only papers'
+    date: '2027-01-26 23:59:00'
+    timezone: UTC
+    utc: '2027-01-26T23:59:00Z'
+  - type: abstract
+    label: Abstract Deadline
+    date: '2028-01-19 23:59:00'
+    timezone: UTC
+    utc: '2028-01-19T23:59:00Z'
+  - type: submission
+    label: 'From GECCO 2026: Full papers (traditional category)'
+    date: '2028-01-26 23:59:00'
+    timezone: UTC
+    utc: '2028-01-26T23:59:00Z'
+  full_name: Genetic and Evolutionary Computation Conference
+  start: '2028-07-12'
+  end: '2028-07-17'
+  approx: true
+  next_deadline: '2027-01-26T23:59:00Z'
+- id: icml2027
+  title: ICML
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - machine-learning
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2026-01-24 11:59:59'
+    timezone: UTC
+    utc: '2026-01-24T11:59:59Z'
+  - type: submission
+    label: 'From ICML 2026: Paper Submissions Open on OpenReview Jan 08 2026 12:00AM UTC-0'
+    date: '2027-01-29 11:59:59'
+    timezone: UTC
+    utc: '2027-01-29T11:59:59Z'
+  full_name: International Conference on Machine Learning
+  start: '2027-07-06'
+  end: '2027-07-11'
+  hindex: 272
+  approx: true
+  next_deadline: '2027-01-29T11:59:59Z'
+- id: rss2027
+  title: RSS
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - machine-learning
+  - robotics
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2027-01-31 22:59:59'
+    timezone: UTC
+    utc: '2027-01-31T22:59:59Z'
+  full_name: Robotics Science and Systems
+  start: '2027-07-13'
+  end: '2027-07-18'
+  approx: true
+  next_deadline: '2027-01-31T22:59:59Z'
+- id: ijcnn2027
+  title: IJCNN
   year: 2027
   areas:
   - AI
@@ -801,18 +1363,99 @@
   deadlines:
   - type: submission
     label: Paper Submission
-    date: '2026-07-28 23:59:59'
-    timezone: AoE
-    utc: '2026-07-29T11:59:59Z'
-  full_name: AAAI Conference on Artificial Intelligence
-  link: https://aaai.org/conference/aaai/aaai-27/
-  place: Canada (Montréal)
-  date: February 16, 2027
-  start: '2027-02-16'
-  end: '2027-02-16'
-- id: accv-2026
-  title: ACCV
-  year: 2026
+    date: '2027-02-01 11:59:59'
+    timezone: UTC
+    utc: '2027-02-01T11:59:59Z'
+  full_name: International Joint Conference on Neural Networks
+  link: https://ijcnn.org/2027
+  start: '2027-06-14'
+  end: '2027-06-18'
+  next_deadline: '2027-02-01T11:59:59Z'
+- id: kdd2027
+  title: KDD
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - data-mining
+  - machine-learning
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2027-02-01 23:59:59'
+    timezone: UTC
+    utc: '2027-02-01T23:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2027-02-08 23:59:59'
+    timezone: UTC
+    utc: '2027-02-08T23:59:59Z'
+  full_name: ACM SIGKDD Conference on Knowledge Discovery and Data Mining
+  start: '2027-08-09'
+  end: '2027-08-14'
+  hindex: 124
+  approx: true
+  next_deadline: '2027-02-01T23:59:59Z'
+- id: mathai2027
+  title: MathAI
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - machine-learning
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2027-02-01 23:59:59'
+    timezone: UTC
+    utc: '2027-02-01T23:59:59Z'
+  - type: submission
+    label: 'From MathAI 2026: Full paper submission deadline'
+    date: '2027-02-19 23:59:59'
+    timezone: UTC
+    utc: '2027-02-19T23:59:59Z'
+  full_name: The International Conference dedicated to mathematics in artificial intelligence
+  start: '2027-03-30'
+  end: '2027-04-04'
+  approx: true
+  next_deadline: '2027-02-01T23:59:59Z'
+- id: sgp2027
+  title: SGP
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - computer-vision
+  - machine-learning
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2027-02-02 22:59:00'
+    timezone: UTC
+    utc: '2027-02-02T22:59:00Z'
+  - type: submission
+    label: Paper Submission
+    date: '2027-02-04 22:59:00'
+    timezone: UTC
+    utc: '2027-02-04T22:59:00Z'
+  - type: abstract
+    label: Abstract Deadline
+    date: '2027-04-13 22:59:00'
+    timezone: UTC
+    utc: '2027-04-13T22:59:00Z'
+  - type: submission
+    label: Paper Submission
+    date: '2027-04-15 22:59:00'
+    timezone: UTC
+    utc: '2027-04-15T22:59:00Z'
+  full_name: Symposium on Geometry Processing
+  start: '2027-07-01'
+  end: '2027-07-06'
+  approx: true
+  next_deadline: '2027-02-02T22:59:00Z'
+- id: colt2027
+  title: COLT
+  year: 2027
   areas:
   - AI
   tags:
@@ -820,15 +1463,1025 @@
   deadlines:
   - type: submission
     label: Paper Submission
-    date: '2026-07-05 23:59:59'
+    date: '2027-02-05 11:59:59'
+    timezone: UTC
+    utc: '2027-02-05T11:59:59Z'
+  full_name: Annual Conference on Learning Theory
+  start: '2027-06-29'
+  end: '2027-07-04'
+  approx: true
+  next_deadline: '2027-02-05T11:59:59Z'
+- id: kr2027
+  title: KR
+  year: 2027
+  areas:
+  - AI
+  - NLP
+  tags:
+  - machine-learning
+  - natural-language-processing
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2027-02-08 23:59:59'
+    timezone: UTC
+    utc: '2027-02-08T23:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2027-02-13 23:59:59'
+    timezone: UTC
+    utc: '2027-02-13T23:59:59Z'
+  full_name: International Conference on Principles of Knowledge Representation and Reasoning
+  start: '2027-07-20'
+  end: '2027-07-25'
+  approx: true
+  next_deadline: '2027-02-08T23:59:59Z'
+- id: miccai2027
+  title: MICCAI
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - computer-vision
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2027-02-13 07:59:59'
+    timezone: UTC
+    utc: '2027-02-13T07:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2027-02-27 07:59:59'
+    timezone: UTC
+    utc: '2027-02-27T07:59:59Z'
+  full_name: International Conference on Medical Image Computing and Computer-Assisted Intervention
+  start: '2027-10-04'
+  end: '2027-10-09'
+  approx: true
+  next_deadline: '2027-02-13T07:59:59Z'
+- id: conll2027
+  title: CoNLL
+  year: 2027
+  areas:
+  - AI
+  - NLP
+  tags:
+  - natural-language-processing
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2027-02-20 11:59:59'
+    timezone: UTC
+    utc: '2027-02-20T11:59:59Z'
+  full_name: The SIGNLL Conference on Computational Natural Language Learning
+  start: '2027-07-03'
+  end: '2027-07-08'
+  hindex: 30
+  approx: true
+  next_deadline: '2027-02-20T11:59:59Z'
+- id: iros2027
+  title: IROS
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - robotics
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2027-03-01 23:59:59'
+    timezone: UTC
+    utc: '2027-03-01T23:59:59Z'
+  start: '2027-10-19'
+  end: '2027-10-24'
+  hindex: 86
+  approx: true
+  next_deadline: '2027-03-01T23:59:59Z'
+- id: rlc2027
+  title: RLC
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - machine-learning
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2027-03-02 12:00:00'
+    timezone: UTC
+    utc: '2027-03-02T12:00:00Z'
+  - type: submission
+    label: 'From RLC 2026: Paper submission'
+    date: '2027-03-06 12:00:00'
+    timezone: UTC
+    utc: '2027-03-06T12:00:00Z'
+  full_name: Reinforcement Learning Conference
+  start: '2027-08-16'
+  end: '2027-08-21'
+  approx: true
+  next_deadline: '2027-03-02T12:00:00Z'
+- id: interspeech2027
+  title: Interspeech
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - signal-processing
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2027-03-03 11:59:59'
+    timezone: UTC
+    utc: '2027-03-03T11:59:59Z'
+  full_name: Interspeech
+  start: '2027-09-27'
+  end: '2027-10-02'
+  approx: true
+  next_deadline: '2027-03-03T11:59:59Z'
+- id: iccv2027
+  title: ICCV
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - computer-vision
+  - machine-learning
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2027-03-04 09:59:00'
+    timezone: UTC
+    utc: '2027-03-04T09:59:00Z'
+  - type: submission
+    label: Paper Submission
+    date: '2027-03-08 09:59:00'
+    timezone: UTC
+    utc: '2027-03-08T09:59:00Z'
+  full_name: International Conference on Computer Vision
+  start: '2027-10-21'
+  end: '2027-10-26'
+  hindex: 256
+  approx: true
+  next_deadline: '2027-03-04T09:59:00Z'
+- id: ecmlpkdd2027
+  title: ECML PKDD
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - data-mining
+  - machine-learning
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2027-03-06 11:59:59'
+    timezone: UTC
+    utc: '2027-03-06T11:59:59Z'
+  - type: submission
+    label: 'From ECMLPKDD 2026: Paper submission (Research Track)'
+    date: '2027-03-13 11:59:59'
+    timezone: UTC
+    utc: '2027-03-13T11:59:59Z'
+  full_name: European Conference on Machine Learning and Principles and Practice of Knowledge Discovery
+    in Databases
+  start: '2027-09-07'
+  end: '2027-09-12'
+  approx: true
+  next_deadline: '2027-03-06T11:59:59Z'
+- id: roman2027
+  title: Ro-Man
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - robotics
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2027-03-15 23:59:59'
+    timezone: UTC
+    utc: '2027-03-15T23:59:59Z'
+  start: '2027-08-24'
+  end: '2027-08-29'
+  approx: true
+  next_deadline: '2027-03-15T23:59:59Z'
+- id: icann2027
+  title: ICANN
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - machine-learning
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2027-03-16 23:59:59'
+    timezone: UTC
+    utc: '2027-03-16T23:59:59Z'
+  full_name: International Conference on Artificial Neural Networks
+  start: '2027-09-14'
+  end: '2027-09-19'
+  approx: true
+  next_deadline: '2027-03-16T23:59:59Z'
+- id: smc2027
+  title: SMC
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - robotics
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2027-03-22 23:59:59'
+    timezone: UTC
+    utc: '2027-03-22T23:59:59Z'
+  full_name: IEEE International Conference on Systems, Man, and Cybernetics
+  start: '2027-10-04'
+  end: '2027-10-09'
+  approx: true
+  next_deadline: '2027-03-22T23:59:59Z'
+- id: colm2027
+  title: COLM
+  year: 2027
+  areas:
+  - AI
+  - NLP
+  tags:
+  - natural-language-processing
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2027-03-27 11:59:59'
+    timezone: UTC
+    utc: '2027-03-27T11:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2027-04-01 11:59:59'
+    timezone: UTC
+    utc: '2027-04-01T11:59:59Z'
+  full_name: Conference on Language Modeling
+  start: '2027-10-06'
+  end: '2027-10-11'
+  approx: true
+  next_deadline: '2027-03-27T11:59:59Z'
+- id: acmmm2027
+  title: ACM MM
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - computer-vision
+  - human-computer-interaction
+  - machine-learning
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2027-04-05 11:59:59'
+    timezone: UTC
+    utc: '2027-04-05T11:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2027-04-12 11:59:59'
+    timezone: UTC
+    utc: '2027-04-12T11:59:59Z'
+  full_name: ACM Multimedia
+  start: '2027-10-27'
+  end: '2027-11-01'
+  hindex: 101
+  approx: true
+  next_deadline: '2027-04-05T11:59:59Z'
+- id: collas2027
+  title: CoLLAs
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - machine-learning
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2027-04-10 23:59:00'
+    timezone: UTC
+    utc: '2027-04-10T23:59:00Z'
+  - type: submission
+    label: 'From CoLLAs 2026: Paper submission deadline'
+    date: '2027-04-15 23:59:00'
+    timezone: UTC
+    utc: '2027-04-15T23:59:00Z'
+  full_name: Fifth Conference on Lifelong Learning Agents
+  start: '2027-09-14'
+  end: '2027-09-19'
+  approx: true
+  next_deadline: '2027-04-10T23:59:00Z'
+- id: ijcb2027
+  title: IJCB
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - human-computer-interaction
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2027-04-10 23:59:59'
+    timezone: UTC
+    utc: '2027-04-10T23:59:59Z'
+  full_name: International Joint Conference on Biometrics
+  start: '2027-09-01'
+  end: '2027-09-06'
+  approx: true
+  next_deadline: '2027-04-10T23:59:59Z'
+- id: corl2027
+  title: CoRL
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - machine-learning
+  - robotics
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2027-04-23 23:59:59'
+    timezone: UTC
+    utc: '2027-04-23T23:59:59Z'
+  full_name: The Conference on Robot Learning
+  start: '2027-09-27'
+  end: '2027-10-02'
+  hindex: 76
+  approx: true
+  next_deadline: '2027-04-23T23:59:59Z'
+- id: iconip2027
+  title: ICONIP
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - machine-learning
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2027-05-10 23:59:59'
+    timezone: UTC
+    utc: '2027-05-10T23:59:59Z'
+  full_name: International Conference on Neural Information Processing
+  start: '2027-11-23'
+  end: '2027-11-28'
+  approx: true
+  next_deadline: '2027-05-10T23:59:59Z'
+- id: neurips2027
+  title: NeurIPS
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - machine-learning
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2027-05-15 23:59:59'
+    timezone: UTC
+    utc: '2027-05-15T23:59:59Z'
+  full_name: Neural Information Processing Systems
+  start: '2027-12-02'
+  end: '2027-12-07'
+  hindex: 371
+  approx: true
+  next_deadline: '2027-05-15T23:59:59Z'
+- id: cikm2027
+  title: CIKM
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - data-mining
+  - machine-learning
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2027-05-18 23:59:59'
+    timezone: UTC
+    utc: '2027-05-18T23:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2027-05-25 23:59:59'
+    timezone: UTC
+    utc: '2027-05-25T23:59:59Z'
+  full_name: ACM International Conference on Information and Knowledge Management
+  start: '2027-11-07'
+  end: '2027-11-12'
+  approx: true
+  next_deadline: '2027-05-18T23:59:59Z'
+- id: emnlp2027
+  title: EMNLP
+  year: 2027
+  areas:
+  - AI
+  - NLP
+  tags:
+  - natural-language-processing
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2027-05-20 11:59:59'
+    timezone: UTC
+    utc: '2027-05-20T11:59:59Z'
+  full_name: The annual Conference on Empirical Methods in Natural Language Processing
+  start: '2027-10-24'
+  end: '2027-10-29'
+  hindex: 218
+  approx: true
+  next_deadline: '2027-05-20T11:59:59Z'
+- id: bmvc2027
+  title: BMVC
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - computer-vision
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2027-05-22 23:59:59'
+    timezone: UTC
+    utc: '2027-05-22T23:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2027-05-29 23:59:59'
+    timezone: UTC
+    utc: '2027-05-29T23:59:59Z'
+  full_name: British Machine Vision Conference
+  start: '2027-11-23'
+  end: '2027-11-28'
+  hindex: 57
+  approx: true
+  next_deadline: '2027-05-22T23:59:59Z'
+- id: ijcnlp2027
+  title: IJCNLP
+  year: 2027
+  areas:
+  - AI
+  - NLP
+  tags:
+  - natural-language-processing
+  deadlines:
+  - type: submission
+    label: 'From IJCNLP 2026: ARR Submission; AACL-IJCNLP 2026 (the 5th AACL & 15th IJCNLP)'
+    date: '2027-05-26 11:59:59'
+    timezone: UTC
+    utc: '2027-05-26T11:59:59Z'
+  full_name: International Joint Conference on Natural Language Processing
+  start: '2027-11-06'
+  end: '2027-11-11'
+  hindex: 41
+  approx: true
+  next_deadline: '2027-05-26T11:59:59Z'
+- id: nlpcc2027
+  title: NLPCC
+  year: 2027
+  areas:
+  - AI
+  - NLP
+  tags:
+  - natural-language-processing
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2027-05-26 23:59:59'
+    timezone: UTC
+    utc: '2027-05-26T23:59:59Z'
+  full_name: CCF International Conference on Natural Language Processing and Chinese Computing
+  start: '2027-11-03'
+  end: '2027-11-08'
+  approx: true
+  next_deadline: '2027-05-26T23:59:59Z'
+- id: icdm2027
+  title: ICDM
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - data-mining
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2027-05-30 23:59:59'
+    timezone: UTC
+    utc: '2027-05-30T23:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2027-06-06 23:59:59'
+    timezone: UTC
+    utc: '2027-06-06T23:59:59Z'
+  full_name: IEEE International Conference on Data Mining
+  start: '2027-11-12'
+  end: '2027-11-17'
+  hindex: 50
+  approx: true
+  next_deadline: '2027-05-30T23:59:59Z'
+- id: acml2027
+  title: ACML
+  year: 2027
+  areas:
+  - AI
+  - NLP
+  tags:
+  - computer-vision
+  - machine-learning
+  - natural-language-processing
+  deadlines:
+  - type: submission
+    label: 'From ACML 2026: Journal Track'
+    date: '2027-06-07 11:59:59'
+    timezone: UTC
+    utc: '2027-06-07T11:59:59Z'
+  - type: submission
+    label: 'From ACML 2026: Conference Track'
+    date: '2027-06-27 11:59:59'
+    timezone: UTC
+    utc: '2027-06-27T11:59:59Z'
+  full_name: Asian Conference on Machine Learning
+  start: '2027-12-01'
+  end: '2027-12-06'
+  approx: true
+  next_deadline: '2027-06-07T11:59:59Z'
+- id: pricai2027
+  title: PRICAI
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - machine-learning
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2027-06-13 23:59:59'
+    timezone: UTC
+    utc: '2027-06-13T23:59:59Z'
+  full_name: Pacific Rim International Conference on Artificial Intelligence
+  start: '2027-11-17'
+  end: '2027-11-22'
+  approx: true
+  next_deadline: '2027-06-13T23:59:59Z'
+- id: wacv2028
+  title: WACV
+  year: 2028
+  areas:
+  - AI
+  tags:
+  - computer-vision
+  - machine-learning
+  deadlines:
+  - type: submission
+    label: 'From WACV 2027: Round 1'
+    date: '2027-07-18 23:59:59'
+    timezone: UTC
+    utc: '2027-07-18T23:59:59Z'
+  start: '2028-03-04'
+  end: '2028-03-09'
+  hindex: 131
+  approx: true
+  next_deadline: '2027-07-18T23:59:59Z'
+- id: aaai2028
+  title: AAAI
+  year: 2028
+  areas:
+  - AI
+  - NLP
+  tags:
+  - computer-vision
+  - data-mining
+  - machine-learning
+  - natural-language-processing
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2027-07-21 11:59:59'
+    timezone: UTC
+    utc: '2027-07-21T11:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2027-07-28 11:59:59'
+    timezone: UTC
+    utc: '2027-07-28T11:59:59Z'
+  full_name: AAAI Conference on Artificial Intelligence
+  start: '2028-02-16'
+  end: '2028-02-21'
+  hindex: 232
+  approx: true
+  next_deadline: '2027-07-21T11:59:59Z'
+- id: dai2027
+  title: DAI
+  year: 2027
+  areas:
+  - AI
+  tags: []
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2027-07-28 11:59:59'
+    timezone: UTC
+    utc: '2027-07-28T11:59:59Z'
+  - type: submission
+    label: 'From DAI 2026: Research / Industry Track'
+    date: '2027-08-04 11:59:59'
+    timezone: UTC
+    utc: '2027-08-04T11:59:59Z'
+  - type: submission
+    label: 'From DAI 2026: AI Paper Track'
+    date: '2027-08-11 11:59:59'
+    timezone: UTC
+    utc: '2027-08-11T11:59:59Z'
+  full_name: International Conference on Distributed Artificial Intelligence
+  start: '2027-11-29'
+  end: '2027-12-04'
+  approx: true
+  next_deadline: '2027-07-28T11:59:59Z'
+- id: humanoids2027
+  title: Humanoids
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - robotics
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2027-07-31 23:59:59'
+    timezone: UTC
+    utc: '2027-07-31T23:59:59Z'
+  start: '2027-12-06'
+  end: '2027-12-11'
+  approx: true
+  next_deadline: '2027-07-31T23:59:59Z'
+- id: eacl2028
+  title: EACL
+  year: 2028
+  areas:
+  - AI
+  - NLP
+  tags:
+  - natural-language-processing
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2027-08-04 11:59:59'
+    timezone: UTC
+    utc: '2027-08-04T11:59:59Z'
+  full_name: The Annual Conference of the European Chapter of the Association for Computational Linguistics
+  start: '2028-03-08'
+  end: '2028-03-13'
+  hindex: 77
+  approx: true
+  next_deadline: '2027-08-04T11:59:59Z'
+- id: wsdm2028
+  title: WSDM
+  year: 2028
+  areas:
+  - AI
+  tags:
+  - data-mining
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2027-08-12 11:59:59'
+    timezone: UTC
+    utc: '2027-08-12T11:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2027-08-19 11:59:59'
+    timezone: UTC
+    utc: '2027-08-19T11:59:59Z'
+  full_name: International Conference on Web Search and Data Mining
+  start: '2028-02-15'
+  end: '2028-02-20'
+  hindex: 77
+  approx: true
+  next_deadline: '2027-08-12T11:59:59Z'
+- id: iui2028
+  title: IUI
+  year: 2028
+  areas:
+  - AI
+  tags:
+  - human-computer-interaction
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2027-08-14 11:59:59'
+    timezone: UTC
+    utc: '2027-08-14T11:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2027-08-21 11:59:59'
+    timezone: UTC
+    utc: '2027-08-21T11:59:59Z'
+  full_name: ACM Conference on Intelligent User Interfaces
+  start: '2028-02-08'
+  end: '2028-02-13'
+  approx: true
+  next_deadline: '2027-08-14T11:59:59Z'
+- id: threedv2028
+  title: 3DV
+  year: 2028
+  areas:
+  - AI
+  tags:
+  - computer-vision
+  - machine-learning
+  deadlines:
+  - type: submission
+    label: 'From 3DV 2027: Supplementary material due Sep 2, 2026. All deadlines are 11:00 am PDT.'
+    date: '2027-08-28 23:00:00'
+    timezone: UTC
+    utc: '2027-08-28T23:00:00Z'
+  full_name: International Conference on 3D Vision
+  start: '2028-04-06'
+  end: '2028-04-11'
+  hindex: 56
+  approx: true
+  next_deadline: '2027-08-28T23:00:00Z'
+- id: chi2028
+  title: CHI
+  year: 2028
+  areas:
+  - AI
+  tags:
+  - human-computer-interaction
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2027-09-11 11:59:59'
+    timezone: UTC
+    utc: '2027-09-11T11:59:59Z'
+  full_name: ACM Conference on Human Factors in Computing Systems
+  start: '2028-05-09'
+  end: '2028-05-14'
+  approx: true
+  next_deadline: '2027-09-11T11:59:59Z'
+- id: iclr2028
+  title: ICLR
+  year: 2028
+  areas:
+  - AI
+  - NLP
+  tags:
+  - computer-vision
+  - data-mining
+  - machine-learning
+  - natural-language-processing
+  - robotics
+  - signal-processing
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2027-09-12 11:59:59'
+    timezone: UTC
+    utc: '2027-09-12T11:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2027-09-17 11:59:59'
+    timezone: UTC
+    utc: '2027-09-17T11:59:59Z'
+  full_name: International Conference on Learning Representations
+  start: '2028-04-27'
+  end: '2028-05-02'
+  hindex: 362
+  approx: true
+  next_deadline: '2027-09-12T11:59:59Z'
+- id: icassp2028
+  title: ICASSP
+  year: 2028
+  areas:
+  - AI
+  tags:
+  - signal-processing
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2027-09-17 11:59:59'
+    timezone: UTC
+    utc: '2027-09-17T11:59:59Z'
+  full_name: IEEE International Conference on Acoustics, Speech, and Signal Processing
+  start: '2028-05-15'
+  end: '2028-05-20'
+  approx: true
+  next_deadline: '2027-09-17T11:59:59Z'
+- id: eurographics2028
+  title: Eurographics
+  year: 2028
+  areas:
+  - AI
+  tags: []
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2027-09-25 23:59:59'
+    timezone: UTC
+    utc: '2027-09-25T23:59:59Z'
+  - type: submission
+    label: 'From Eurographics 2027: Full paper submission deadline'
+    date: '2027-10-01 23:59:59'
+    timezone: UTC
+    utc: '2027-10-01T23:59:59Z'
+  full_name: The 48th Annual Conference of the European Association for Computer Graphics
+  start: '2028-05-10'
+  end: '2028-05-15'
+  approx: true
+  next_deadline: '2027-09-25T23:59:59Z'
+- id: aistats2028
+  title: AISTATS
+  year: 2028
+  areas:
+  - AI
+  tags:
+  - machine-learning
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2027-09-26 11:59:59'
+    timezone: UTC
+    utc: '2027-09-26T11:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2027-10-03 11:59:59'
+    timezone: UTC
+    utc: '2027-10-03T11:59:59Z'
+  full_name: International Conference on Artificial Intelligence and Statistics
+  start: '2028-05-01'
+  end: '2028-05-06'
+  hindex: 101
+  approx: true
+  next_deadline: '2027-09-26T11:59:59Z'
+- id: ecir2028
+  title: ECIR
+  year: 2028
+  areas:
+  - AI
+  tags:
+  - data-mining
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2027-09-26 11:59:59'
+    timezone: UTC
+    utc: '2027-09-26T11:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2027-10-03 11:59:59'
+    timezone: UTC
+    utc: '2027-10-03T11:59:59Z'
+  full_name: European Conference on Information Retrieval
+  start: '2028-03-21'
+  end: '2028-03-26'
+  approx: true
+  next_deadline: '2027-09-26T11:59:59Z'
+- id: aaai2027
+  title: AAAI
+  year: 2027
+  areas:
+  - AI
+  - NLP
+  tags:
+  - computer-vision
+  - data-mining
+  - machine-learning
+  - natural-language-processing
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2026-07-22 11:59:59'
+    timezone: UTC
+    utc: '2026-07-22T11:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2026-07-29 11:59:59'
+    timezone: UTC
+    utc: '2026-07-29T11:59:59Z'
+  full_name: AAAI Conference on Artificial Intelligence
+  link: https://aaai.org/conference/aaai/aaai-27/
+  start: '2027-02-16'
+  end: '2027-02-23'
+  hindex: 232
+- id: aacl26
+  title: AACL
+  year: 2026
+  areas:
+  - AI
+  - NLP
+  tags:
+  - natural-language-processing
+  deadlines:
+  - type: arr_submission
+    label: ARR Final Submission
+    date: '2026-05-25 23:59:59'
     timezone: AoE
+    utc: '2026-05-26T11:59:59Z'
+  - type: commitment
+    label: ARR Commitment
+    date: '2026-08-02 23:59:59'
+    timezone: AoE
+    utc: '2026-08-03T11:59:59Z'
+  link: https://2026.aaclnet.org/
+  note: Submissions via ACL Rolling Review
+- id: accv2026
+  title: ACCV
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - computer-vision
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-07-06 11:59:59'
+    timezone: UTC
     utc: '2026-07-06T11:59:59Z'
   full_name: Asian Conference on Computer Vision
   link: https://accv2026.org/
-  place: Japan (Osaka)
-  date: December 14, 2026
+  place: Osaka, Japan
   start: '2026-12-14'
-  end: '2026-12-14'
+  end: '2026-12-18'
+  hindex: 52
+- id: acm26
+  title: ACM MM
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - computer-vision
+  - human-computer-interaction
+  - machine-learning
+  deadlines:
+  - type: abstract
+    label: Contribution registration
+    date: '2026-03-25 23:59:59'
+    timezone: AoE
+    utc: '2026-03-26T11:59:59Z'
+  - type: paper
+    label: Contribution submission
+    date: '2026-04-01 23:59:59'
+    timezone: AoE
+    utc: '2026-04-02T11:59:59Z'
+  - type: supplementary
+    label: Supplementary material submission
+    date: '2026-04-08 23:59:59'
+    timezone: AoE
+    utc: '2026-04-09T11:59:59Z'
+  - type: rebuttal_start
+    label: Rebuttal period start
+    date: '2026-06-04 23:59:59'
+    timezone: AoE
+    utc: '2026-06-05T11:59:59Z'
+  - type: notification
+    label: Author notification
+    date: '2026-07-09 23:59:59'
+    timezone: AoE
+    utc: '2026-07-10T11:59:59Z'
+  - type: camera_ready
+    label: Camera-ready submission
+    date: '2026-08-06 23:59:59'
+    timezone: AoE
+    utc: '2026-08-07T11:59:59Z'
+  - type: registration
+    label: Author registration
+    date: '2026-08-20 23:59:59'
+    timezone: AoE
+    utc: '2026-08-21T11:59:59Z'
+  full_name: ACM Multimedia
+  link: https://2026.acmmm.org/
+  place: Rio de Janeiro, Brazil
+  date: November 10-14, 2026
+  start: '2026-11-10'
+  end: '2026-11-14'
+  note: All important dates can be found <a href='https://2026.acmmm.org/site/important-dates.html'>here</a>.
+    The time for all dates is 23:59 AoE (Anywhere-on-Earth).
+- id: acml2026
+  title: ACML
+  year: 2026
+  areas:
+  - AI
+  - NLP
+  tags:
+  - computer-vision
+  - machine-learning
+  - natural-language-processing
+  deadlines:
+  - type: submission
+    label: Journal Track
+    date: '2026-06-21 11:59:59'
+    timezone: UTC
+    utc: '2026-06-21T11:59:59Z'
+  - type: submission
+    label: Conference Track
+    date: '2026-07-06 11:59:59'
+    timezone: UTC
+    utc: '2026-07-06T11:59:59Z'
+  full_name: Asian Conference on Machine Learning
+  link: https://www.acml-conf.org/2026/
+  start: '2026-12-01'
+  end: '2026-12-04'
 - id: apsys26
   title: APSys
   year: 2026
@@ -942,8 +2595,31 @@
   date: November 15-18, 2026
   start: '2026-11-15'
   end: '2026-11-18'
-- id: bmvc
+- id: bmvc2026
   title: BMVC
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - computer-vision
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2026-05-23 11:59:59'
+    timezone: UTC
+    utc: '2026-05-23T11:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2026-05-30 11:59:59'
+    timezone: UTC
+    utc: '2026-05-30T11:59:59Z'
+  full_name: British Machine Vision Conference
+  link: https://bmvc2026.bmva.org/
+  start: '2026-11-23'
+  end: '2026-11-26'
+  hindex: 57
+- id: cicai2026
+  title: CICAI
   year: 2026
   areas:
   - AI
@@ -952,36 +2628,57 @@
   deadlines:
   - type: submission
     label: Paper Submission
-    date: '2026-05-29 23:59:59'
-    timezone: AoE
-    utc: '2026-05-30T11:59:59Z'
-  full_name: British Machine Vision Conference
-  link: https://bmvc2026.bmva.org/
-  place: UK (Lancaster)
-  date: November 23, 2026
-  start: '2026-11-23'
-  end: '2026-11-23'
-- id: chi27
-  title: CHI
-  year: 2027
+    date: '2026-06-09 11:59:59'
+    timezone: UTC
+    utc: '2026-06-09T11:59:59Z'
+  full_name: CAAI International Conference on Artificial Intelligence
+  link: https://cicai.caai.cn/index.html
+  start: '2026-10-17'
+  end: '2026-10-19'
+- id: cikm26
+  title: CIKM
+  year: 2026
   areas:
   - AI
   tags:
-  - human-computer-interaction
-  deadlines: []
-  full_name: The ACM Conference on Human Factors in Computing Systems
-  link: https://chi2027.acm.org/
-  place: Pittsburgh, United States
-  date: May 10 - May 14, 2027
-  start: '2027-05-10'
-  end: '2027-05-14'
-  note: Submission deadlines to be announced. More info <a href='https://chi2027.acm.org/'>here</a>.
-  hindex: 128
+  - data-mining
+  - machine-learning
+  - web-search
+  deadlines:
+  - type: abstract
+    label: Abstract submission deadline
+    date: '2026-05-16 23:59:00'
+    timezone: AoE
+    utc: '2026-05-17T11:59:00Z'
+  - type: paper
+    label: Full paper submission deadline
+    date: '2026-05-23 23:59:00'
+    timezone: AoE
+    utc: '2026-05-24T11:59:00Z'
+  - type: notification
+    label: Author notification
+    date: '2026-08-07 23:59:00'
+    timezone: AoE
+    utc: '2026-08-08T11:59:00Z'
+  - type: camera_ready
+    label: Camera-ready deadline
+    date: '2026-08-20 23:59:00'
+    timezone: AoE
+    utc: '2026-08-21T11:59:00Z'
+  full_name: Conference on Information and Knowledge Management
+  link: https://cikm2026.diag.uniroma1.it/
+  place: Rome, Italy
+  date: November 7-11, 2026
+  start: '2026-11-07'
+  end: '2026-11-11'
+  note: All deadlines are at 11:59pm AoE
+  hindex: 91.0
 - id: colm26
   title: COLM
   year: 2026
   areas:
   - AI
+  - NLP
   tags:
   - large-language-models
   - natural-language-processing
@@ -1088,56 +2785,32 @@
   start: '2026-11-09'
   end: '2026-11-12'
   note: Workshops on Nov 9, main conference Nov 10-12
-- id: ecai26
-  title: ECAI
+- id: dai2026
+  title: DAI
   year: 2026
   areas:
   - AI
-  tags:
-  - machine-learning
+  tags: []
   deadlines:
   - type: abstract
-    label: Abstract submission deadline
-    date: '2026-01-12 23:59:59'
-    timezone: AoE
-    utc: '2026-01-13T11:59:59Z'
-  - type: paper
-    label: Full paper submission deadline
-    date: '2026-01-19 23:59:59'
-    timezone: AoE
-    utc: '2026-01-20T11:59:59Z'
-  - type: notification
-    label: Summary rejection notification
-    date: '2026-03-04 23:59:59'
-    timezone: AoE
-    utc: '2026-03-05T11:59:59Z'
-  - type: rebuttal_start
-    label: Author response period start
-    date: '2026-04-07 23:59:59'
-    timezone: AoE
-    utc: '2026-04-08T11:59:59Z'
-  - type: rebuttal_end
-    label: Author response period end
-    date: '2026-04-10 23:59:59'
-    timezone: AoE
-    utc: '2026-04-11T11:59:59Z'
-  - type: notification
-    label: Paper notification
-    date: '2026-04-29 23:59:59'
-    timezone: AoE
-    utc: '2026-04-30T11:59:59Z'
-  - type: camera_ready
-    label: Camera-ready deadline
-    date: '2026-05-15 23:59:59'
-    timezone: AoE
-    utc: '2026-05-16T11:59:59Z'
-  full_name: European Conference on Artificial Intelligence
-  link: https://2026.ijcai.org/
-  place: Bremen, Germany
-  date: August 15-21, 2026
-  start: '2026-08-15'
-  end: '2026-08-21'
-  note: Joint conference with IJCAI 2026 (IJCAI-ECAI 2026). All important dates can be found <a href='https://2026.ijcai.org/important-dates/'>here</a>.
+    label: Abstract Deadline
+    date: '2026-07-28 11:59:59'
+    timezone: UTC
+    utc: '2026-07-28T11:59:59Z'
+  - type: submission
+    label: Research / Industry Track
+    date: '2026-08-04 11:59:59'
+    timezone: UTC
+    utc: '2026-08-04T11:59:59Z'
+  - type: submission
+    label: AI Paper Track
+    date: '2026-08-11 11:59:59'
+    timezone: UTC
+    utc: '2026-08-11T11:59:59Z'
+  full_name: International Conference on Distributed Artificial Intelligence
+  link: https://www.adai.ai/dai/2026/index.html
+  start: '2026-11-29'
+  end: '2026-12-02'
 - id: eccv26
   title: ECCV
   year: 2026
@@ -1212,21 +2885,6 @@
   date: September 8-12, 2026
   start: '2026-09-08'
   end: '2026-09-12'
-- id: ecir27
-  title: ECIR
-  year: 2027
-  areas:
-  - AI
-  tags:
-  - data-mining
-  deadlines: []
-  full_name: European Conference on Information Retrieval
-  link: https://www.ecir2027.co.uk/
-  place: Southampton, United Kingdom
-  date: March 21 - March 25, 2027
-  start: '2027-03-21'
-  end: '2027-03-25'
-  note: More info <a href='https://www.ecir2027.co.uk/'>here</a>. Submission deadlines TBA.
 - id: ecmlpkdd26
   title: ECML PKDD
   year: 2026
@@ -1268,6 +2926,7 @@
   year: 2026
   areas:
   - AI
+  - NLP
   tags:
   - natural-language-processing
   deadlines: []
@@ -1436,6 +3095,23 @@
   date: November 16-17, 2026
   start: '2026-11-16'
   end: '2026-11-17'
+- id: humanoids2026
+  title: Humanoids
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - robotics
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-07-31 23:59:59'
+    timezone: UTC
+    utc: '2026-07-31T23:59:59Z'
+  link: https://2026.ieee-humanoids.org/
+  place: Santa Clara, California
+  start: '2026-12-06'
+  end: '2026-12-09'
 - id: icann26
   title: ICANN
   year: 2026
@@ -1577,6 +3253,41 @@
   date: August 18-22, 2027
   start: '2027-08-18'
   end: '2027-08-22'
+- id: icdl2026
+  title: ICDL
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - robotics
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-03-13 23:59:59'
+    timezone: UTC
+    utc: '2026-03-13T23:59:59Z'
+  link: https://attend.ieee.org/icdl-2026/
+  place: Kyoto, Japan
+  start: '2026-09-15'
+  end: '2026-09-18'
+- id: icip2026
+  title: ICIP
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - computer-vision
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-02-05 11:59:59'
+    timezone: UTC
+    utc: '2026-02-05T11:59:59Z'
+  full_name: The IEEE International Conference on Image Processing
+  link: https://2026.ieeeicip.org/
+  start: '2026-09-13'
+  end: '2026-09-17'
+  hindex: 55
 - id: icomp26
   title: ICOMP
   year: 2026
@@ -1592,6 +3303,23 @@
   date: September 11-13, 2026
   start: '2026-09-11'
   end: '2026-09-13'
+- id: iconip2026
+  title: ICONIP
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - machine-learning
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-06-01 11:59:59'
+    timezone: UTC
+    utc: '2026-06-01T11:59:59Z'
+  full_name: International Conference on Neural Information Processing
+  link: https://www.iconip2026.org/
+  start: '2026-11-23'
+  end: '2026-11-27'
 - id: icpp-2026
   title: ICPP
   year: 2026
@@ -1611,21 +3339,23 @@
   date: September 28, 2026
   start: '2026-09-28'
   end: '2026-09-28'
-- id: icra27
-  title: ICRA
-  year: 2027
+- id: ictai2026
+  title: ICTAI
+  year: 2026
   areas:
   - AI
   tags:
-  - computer-vision
-  - robotics
-  deadlines: []
-  full_name: IEEE International Conference on Robotics and Automation
-  link: https://www.ieee-ras.org/conferences-workshops/fully-sponsored/icra/
-  place: Seoul, South Korea
-  date: May 24 - 28, 2027
-  start: '2027-05-24'
-  end: '2027-05-28'
+  - machine-learning
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-07-01 11:59:00'
+    timezone: UTC
+    utc: '2026-07-01T11:59:00Z'
+  full_name: International Conference on Tools with Artificial Intellignce
+  link: https://ictai.computer.org/2026/
+  start: '2026-11-02'
+  end: '2026-11-04'
 - id: IISWC26
   title: IISWC
   year: 2026
@@ -1644,60 +3374,48 @@
   date: September 27-29, 2026
   start: '2026-09-27'
   end: '2026-09-29'
-- id: ijcai26
-  title: IJCAI
+- id: ijcb2026
+  title: IJCB
   year: 2026
   areas:
   - AI
   tags:
-  - machine-learning
+  - human-computer-interaction
   deadlines:
-  - type: abstract
-    label: Abstract submission deadline
-    date: '2026-01-12 23:59:59'
-    timezone: AoE
-    utc: '2026-01-13T11:59:59Z'
-  - type: paper
-    label: Full paper submission deadline
-    date: '2026-01-19 23:59:59'
-    timezone: AoE
-    utc: '2026-01-20T11:59:59Z'
-  - type: notification
-    label: Phase I notification
-    date: '2026-03-04 23:59:59'
-    timezone: AoE
-    utc: '2026-03-05T11:59:59Z'
-  - type: rebuttal_start
-    label: Author response period start
-    date: '2026-04-07 00:00:00'
-    timezone: AoE
-    utc: '2026-04-07T12:00:00Z'
-  - type: rebuttal_end
-    label: Author response period end
-    date: '2026-04-10 23:59:59'
-    timezone: AoE
-    utc: '2026-04-11T11:59:59Z'
-  - type: notification
-    label: Paper notification
-    date: '2026-04-29 23:59:59'
-    timezone: AoE
-    utc: '2026-04-30T11:59:59Z'
-  - type: camera_ready
-    label: Camera ready deadline
-    date: '2026-05-15 23:59:59'
-    timezone: AoE
-    utc: '2026-05-16T11:59:59Z'
-  full_name: International Joint Conference on Artificial Intelligence
-  link: https://2026.ijcai.org/
-  place: Bremen, Germany
-  date: August 15-21, 2026
-  start: '2026-08-15'
-  end: '2026-08-21'
+  - type: submission
+    label: Paper Submission
+    date: '2026-05-01 11:59:59'
+    timezone: UTC
+    utc: '2026-05-01T11:59:59Z'
+  full_name: International Joint Conference on Biometrics
+  link: https://ijcb2026.ieee-biometrics.org/
+  start: '2026-09-01'
+  end: '2026-09-04'
+- id: ijcnlp2026
+  title: IJCNLP
+  year: 2026
+  areas:
+  - AI
+  - NLP
+  tags:
+  - natural-language-processing
+  deadlines:
+  - type: submission
+    label: 'ARR Submission; commitment deadline: 2026-08-02; AACL-IJCNLP 2026 (the 5th AACL & 15th IJCNLP)'
+    date: '2026-05-26 11:59:59'
+    timezone: UTC
+    utc: '2026-05-26T11:59:59Z'
+  full_name: International Joint Conference on Natural Language Processing
+  link: https://2026.aaclnet.org/
+  start: '2026-11-06'
+  end: '2026-11-10'
+  hindex: 41
 - id: inlg2026
   title: INLG
   year: 2026
   areas:
   - AI
+  - NLP
   tags:
   - natural-language-processing
   deadlines:
@@ -1794,6 +3512,28 @@
   link: https://ispass.org/ispass2026/
   place: Seoul, South Korea
   date: April 26-28
+- id: iui2027
+  title: IUI
+  year: 2027
+  areas:
+  - AI
+  tags:
+  - human-computer-interaction
+  deadlines:
+  - type: abstract
+    label: Abstract Deadline
+    date: '2026-08-14 11:59:59'
+    timezone: UTC
+    utc: '2026-08-14T11:59:59Z'
+  - type: submission
+    label: Paper Submission
+    date: '2026-08-21 11:59:59'
+    timezone: UTC
+    utc: '2026-08-21T11:59:59Z'
+  full_name: ACM Conference on Intelligent User Interfaces
+  link: https://iui.hosting.acm.org/2027/
+  start: '2027-02-08'
+  end: '2027-02-11'
 - id: interspeech2026
   title: Interspeech
   year: 2026
@@ -1930,6 +3670,24 @@
   link: https://microarch.org/micro59/index.php
   place: Athens, Greece
   date: October 31 – November 4, 2026
+- id: nlpcc2026
+  title: NLPCC
+  year: 2026
+  areas:
+  - AI
+  - NLP
+  tags:
+  - natural-language-processing
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-06-21 11:59:59'
+    timezone: UTC
+    utc: '2026-06-21T11:59:59Z'
+  full_name: CCF International Conference on Natural Language Processing and Chinese Computing
+  link: http://tcci.ccf.org.cn/conference/2026/
+  start: '2026-11-03'
+  end: '2026-11-05'
 - id: NSDI27spring
   title: NSDI (Spring)
   year: 2027
@@ -1969,6 +3727,22 @@
   link: https://pact2026.github.io/submit
   place: Chicago, IL, USA
   date: October 19-22, 2026
+- id: ppsn2026
+  title: PPSN
+  year: 2026
+  areas:
+  - AI
+  tags: []
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-03-29 11:59:59'
+    timezone: UTC
+    utc: '2026-03-29T11:59:59Z'
+  full_name: International Conference on Parallel Problem Solving From Nature
+  link: https://ppsn2026.disi.unitn.it/
+  start: '2026-08-29'
+  end: '2026-09-02'
 - id: ppopp-2027
   title: PPoPP
   year: 2027
@@ -1988,42 +3762,40 @@
   date: March 20, 2027
   start: '2027-03-20'
   end: '2027-03-20'
-- id: rlc26
-  title: RLC
+- id: pricai2026
+  title: PRICAI
   year: 2026
   areas:
   - AI
   tags:
   - machine-learning
-  - reinforcement-learning
   deadlines:
-  - type: abstract
-    label: Abstract submission
-    date: '2026-03-01 23:59:59'
-    timezone: AoE
-    utc: '2026-03-02T11:59:59Z'
-  - type: paper
-    label: Paper submission
-    date: '2026-03-05 23:59:59'
-    timezone: AoE
-    utc: '2026-03-06T11:59:59Z'
-  - type: notification
-    label: Author notification
-    date: '2026-05-08 23:59:59'
-    timezone: AoE
-    utc: '2026-05-09T11:59:59Z'
-  - type: camera_ready
-    label: Camera-ready deadline
-    date: '2026-07-18 23:59:59'
-    timezone: AoE
-    utc: '2026-07-19T11:59:59Z'
-  full_name: Reinforcement Learning Conference
-  link: https://rl-conference.cc/
-  place: Montreal, Canada
-  date: August 15 - 18, 2026
-  start: '2026-08-15'
-  end: '2026-08-18'
-  note: Mandatory abstract deadline on Mar 1, 2026.
+  - type: submission
+    label: Paper Submission
+    date: '2026-06-28 11:59:59'
+    timezone: UTC
+    utc: '2026-06-28T11:59:59Z'
+  full_name: Pacific Rim International Conference on Artificial Intelligence
+  link: https://2026.pricai.org/
+  start: '2026-11-17'
+  end: '2026-11-20'
+- id: roman2026
+  title: Ro-Man
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - robotics
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-03-15 23:59:59'
+    timezone: UTC
+    utc: '2026-03-15T23:59:59Z'
+  link: https://www.brain.kyutech.ac.jp/~s-yasukawa/ro-man2026/
+  place: Fukuoka, Japan
+  start: '2026-08-24'
+  end: '2026-08-28'
 - id: rulemlrr26
   title: RuleML+RR
   year: 2026
@@ -2135,6 +3907,23 @@
   date: August 8-12, 2027
   start: '2027-08-08'
   end: '2027-08-12'
+- id: smc2026
+  title: SMC
+  year: 2026
+  areas:
+  - AI
+  tags:
+  - robotics
+  deadlines:
+  - type: submission
+    label: Paper Submission
+    date: '2026-05-04 11:59:59'
+    timezone: UTC
+    utc: '2026-05-04T11:59:59Z'
+  full_name: IEEE International Conference on Systems, Man, and Cybernetics
+  link: https://www.ieeesmc2026.org/
+  start: '2026-10-04'
+  end: '2026-10-07'
 - id: sosp26
   title: SOSP
   year: 2026

--- a/_pages/deadlines.md
+++ b/_pages/deadlines.md
@@ -2,7 +2,7 @@
 layout: page
 title: Deadlines
 permalink: /deadlines/
-description: AI 및 컴퓨터 시스템 분야 주요 학회의 논문 마감일을 모아 보여줍니다. 데이터는 매주 자동으로 갱신됩니다.
+description: AI·NLP·컴퓨터 시스템 분야 주요 학회의 논문 마감일과 ACL Rolling Review(ARR) 사이클 일정을 모아 보여줍니다. 데이터는 매주 자동으로 갱신됩니다.
 nav: true
 nav_order: 6
 ---
@@ -136,9 +136,11 @@ nav_order: 6
 }
 
 .dl-badge.area-AI { background: var(--global-theme-color, #4285f4); color: #fff; }
+.dl-badge.area-NLP { background: #673ab7; color: #fff; }
 .dl-badge.area-Systems { background: #34a853; color: #fff; }
 .dl-badge.area-Other { background: var(--global-divider-color, #e5e5e5); color: var(--global-text-color, #333); }
 .dl-badge.tba { background: #fbbc04; color: #333; }
+.dl-badge.approx { background: #e8710a; color: #fff; }
 
 .dl-full {
   font-size: 0.78rem;
@@ -158,6 +160,7 @@ nav_order: 6
 
 .dl-meta .sep { color: var(--global-divider-color, #ccc); margin: 0 0.45rem; }
 .dl-when { font-weight: 600; color: var(--global-text-color, #444); }
+.dl-kind { color: var(--global-text-color-light, #888); margin-left: 0.3rem; }
 
 .dl-empty {
   padding: 2rem 0;
@@ -191,6 +194,7 @@ nav_order: 6
 <div class="dl-controls">
   <button class="dl-filter active" data-area="all" type="button">전체</button>
   <button class="dl-filter" data-area="AI" type="button">AI</button>
+  <button class="dl-filter" data-area="NLP" type="button">NLP</button>
   <button class="dl-filter" data-area="Systems" type="button">Systems</button>
   <input type="search" id="dl-search" placeholder="학회 이름 검색 (예: NeurIPS, ISCA)" aria-label="학회 검색">
   <label class="dl-toggle">
@@ -218,13 +222,17 @@ nav_order: 6
         {{ conf.title }} <span class="dl-year">{{ conf.year }}</span>
         {%- for area in conf.areas %}<span class="dl-badge area-{{ area }}">{{ area }}</span>{% endfor %}
         {%- if conf.tba %}<span class="dl-badge tba">CFP 미발표</span>{% endif %}
+        {%- if conf.approx %}<span class="dl-badge approx">예상 마감</span>{% endif %}
       </p>
       {%- if conf.full_name %}
       <p class="dl-full">{{ conf.full_name }}</p>
       {%- endif %}
       <p class="dl-meta">
         {%- if conf.next_deadline %}
-        <span class="dl-when" data-deadline="{{ conf.next_deadline }}"></span><span class="sep">|</span>
+        {%- assign next_label = "" %}
+        {%- for d in conf.deadlines %}{% if d.utc == conf.next_deadline %}{% assign next_label = d.label %}{% endif %}{% endfor %}
+        <span class="dl-when" data-deadline="{{ conf.next_deadline }}"></span>
+        {%- if next_label != "" %} <span class="dl-kind">{{ next_label }}</span>{% endif %}<span class="sep">|</span>
         {%- endif %}
         {%- if conf.date %}{{ conf.date }}{%- endif %}
         {%- if conf.date and conf.place %}<span class="sep">|</span>{% endif %}
@@ -239,6 +247,8 @@ nav_order: 6
 
 <p class="dl-note">
   마감일은 매주 자동으로 갱신되지만, 실제 마감 시각은 반드시 각 학회 공식 홈페이지에서 확인하시기 바랍니다.
+  NLP 계열 학회(ACL, EMNLP, NAACL 등)는 <a href="https://aclrollingreview.org/dates" target="_blank" rel="noopener">ACL Rolling Review(ARR)</a> 사이클로 제출이 이뤄지므로, ARR 사이클 일정과 학회별 commitment 마감도 함께 표시합니다.
+  <span class="dl-badge approx">예상 마감</span> 표시는 아직 공식 발표 전인 추정 일정입니다.
 </p>
 
 <script>

--- a/bin/sync_deadlines.py
+++ b/bin/sync_deadlines.py
@@ -1,12 +1,19 @@
 #!/usr/bin/env python3
 """학회 논문 마감일 데이터를 공개 저장소에서 가져와 _data/conferences.yml 로 동기화한다.
 
-AI 학회 목록과 컴퓨터 시스템/아키텍처 학회 목록을 각각 유지하는 공개 저장소 두 곳을
-읽어 하나로 합친다. 두 곳은 스키마가 다르므로 공통 형태로 정규화하고, 마감 시각을
-UTC로 미리 변환해 둔다. 브라우저에서 타임존을 다시 계산할 필요 없이 Date 하나로
-카운트다운할 수 있도록 하기 위함이다.
+여러 공개 출처를 읽어 하나로 합친다. 출처마다 스키마가 다르므로 공통 형태로
+정규화하고, 마감 시각을 UTC로 미리 변환해 둔다. 브라우저에서 타임존을 다시 계산할
+필요 없이 Date 하나로 카운트다운할 수 있도록 하기 위함이다.
 
-HF_REPO 의 데이터는 MIT License 로 배포된다 (Copyright (c) 2025 Hugging Face).
+출처:
+  - huggingface/ai-deadlines  — AI 전반 (MIT License, Copyright (c) 2025 Hugging Face)
+  - tobna/ai-deadlines        — aideadlines.org 의 데이터. NLP 계열(ACL/EACL/CoNLL 등)을
+                                포함해 HF 쪽에 없는 학회를 보강한다 (MIT License)
+  - casys-kaist               — 컴퓨터 시스템/아키텍처 학회
+  - IDSL (서울과기대)          — 추가 보강용
+  - aclrollingreview.org      — ARR 리뷰 사이클 일정. *ACL 계열 학회는 ARR 제출로
+                                이뤄지므로 사이클별 제출 마감과 학회별 commitment
+                                날짜를 함께 가져온다
 
 사용법:
 
@@ -33,6 +40,9 @@ HF_DATA_PATH = "src/data/conferences"
 CASYS_REPO = "https://github.com/casys-kaist/casys-kaist.github.io"
 CASYS_DATA_PATH = "_data/conferences"
 IDSL_URL = "https://idsl.seoultech.ac.kr/js/conference-board-data.js"
+TOBNA_REPO = "https://github.com/tobna/ai-deadlines"  # aideadlines.org 데이터
+TOBNA_DATA_PATH = "conferences"
+ARR_URL = "https://raw.githubusercontent.com/acl-org/aclrollingreview/main/dates.md"
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 OUTPUT = os.path.join(REPO_ROOT, "_data", "conferences.yml")
@@ -41,7 +51,24 @@ DATE_FORMATS = ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M", "%Y-%m-%d")
 TBA_WORDS = {"tba", "tbd", "n/a", "none", ""}
 
 # 같은 학회를 다르게 부르는 경우를 묶어 준다. 중복 판정에만 쓴다.
-TITLE_ALIASES = {"MM": "ACM MM", "IJCAI-ECAI": "IJCAI", "ACM-MM": "ACM MM"}
+TITLE_ALIASES = {
+    "MM": "ACM MM",
+    "IJCAI-ECAI": "IJCAI",
+    "ACM-MM": "ACM MM",
+    "ACMMM": "ACM MM",
+    "ECMLPKDD": "ECML PKDD",
+    "RULEMLRR": "RULEML+RR",
+    "IEEE CEC": "CEC",
+    "IJCNLP-AACL": "IJCNLP",
+    "IJCNLPAACL": "IJCNLP",
+    "AACL-IJCNLP": "IJCNLP",
+}
+
+# NLP 계열 학회. ARR(ACL Rolling Review) 제출과 얽혀 있어 NLP 분류를 따로 붙인다.
+NLP_TITLES = {
+    "ACL", "EACL", "NAACL", "AACL", "EMNLP", "COLING", "IJCNLP", "CONLL",
+    "LREC", "NLPCC", "COLM", "INLG", "SIGDIAL", "SEMEVAL", "ARR",
+}
 
 # CASYS 의 sub 코드를 상위 분류로 매핑한다. HF 쪽은 전부 AI 로 본다.
 CASYS_AREA = {"ARCH": "Systems", "SYS": "Systems", "ML": "AI", "OTHER": "Other"}
@@ -65,6 +92,31 @@ IDSL_SYSTEMS = {
     "ISLPED", "ISPASS", "MASCOTS", "MICRO", "PACT", "PPOPP", "VLSI",
 }
 
+# tobna 데이터 안에서 같은 학회가 두 표기로 들어 있는 경우의 표기 통일.
+TOBNA_TITLE = {
+    "ACMMM": "ACM MM",
+    "ECMLPKDD": "ECML PKDD",
+    "RuleMLRR": "RuleML+RR",
+    "IEEE CEC": "CEC",
+    "iROS": "IROS",
+}
+
+# tobna(aideadlines.org) 의 분야 코드를 HF 쪽과 같은 태그 표기로 맞춘다.
+TOBNA_TAG = {
+    "ML": "machine-learning",
+    "CV": "computer-vision",
+    "NLP": "natural-language-processing",
+    "RO": "robotics",
+    "SP": "signal-processing",
+    "DM": "data-mining",
+    "HCI": "human-computer-interaction",
+    "DB": "information-systems",
+}
+
+# 예상(estimate) 마감은 이 기간 안에 드는 것만 취한다. 2~3년 뒤 추정치까지
+# 실으면 목록만 길어지고 신뢰도는 떨어지기 때문이다.
+APPROX_HORIZON_DAYS = 400
+
 
 def sparse_clone(repo, data_path, dest):
     """상류 저장소에서 데이터 디렉터리만 얇게 받아온다."""
@@ -83,14 +135,14 @@ def sparse_clone(repo, data_path, dest):
     return os.path.join(dest, data_path)
 
 
-def fetch_idsl(url):
-    """세 번째 출처의 데이터 파일을 받아 온다. 실패해도 동기화 전체를 막지는 않는다."""
+def fetch_text(url, what):
+    """보조 출처의 텍스트 파일을 받아 온다. 실패해도 동기화 전체를 막지는 않는다."""
     request = urllib.request.Request(url, headers={"User-Agent": "sync-deadlines/1.0"})
     try:
         with urllib.request.urlopen(request, timeout=60) as resp:
             return resp.read().decode("utf-8", errors="replace")
     except Exception as exc:  # 네트워크/서버 문제로 나머지 출처까지 잃지 않도록 한다.
-        print(f"경고: 추가 출처를 가져오지 못했다 ({exc}). 나머지 출처로만 진행한다.",
+        print(f"경고: {what} 출처를 가져오지 못했다 ({exc}). 나머지 출처로만 진행한다.",
               file=sys.stderr)
         return None
 
@@ -160,6 +212,255 @@ def parse_idsl(text):
             entry["tba"] = True
         entries.append(entry)
     return entries
+
+
+def parse_tobna(path, today):
+    """tobna/ai-deadlines(aideadlines.org)의 `conferences/*.yaml` 을 읽는다.
+
+    파일마다 `{id: {shortname, timeline, tags, ...}}` 꼴의 사전이 들어 있다.
+    timeline 의 마감 시각은 이미 UTC(Z 접미사)로 적혀 있다. `estimate` 로 표시된
+    예상 마감은 APPROX_HORIZON_DAYS 안에 드는 것만 취하고 approx 로 표시해 둔다.
+    """
+    horizon = today + dt.timedelta(days=APPROX_HORIZON_DAYS)
+    entries = []
+    for f in sorted(glob.glob(os.path.join(path, "*.yaml"))):
+        with open(f, encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+        if not isinstance(data, dict):
+            continue
+        for key, v in data.items():
+            if not isinstance(v, dict):
+                continue
+            m = re.match(r"(.+?)\s+(\d{4})$", str(v.get("shortname") or "").strip())
+            if not m:
+                continue
+            title, year = m.group(1), int(m.group(2))
+            title = TOBNA_TITLE.get(title, title)
+            approx = bool(v.get("isApproximateDeadline")) or v.get("dataSrc") == "estimate"
+
+            deadlines = []
+            for item in v.get("timeline") or []:
+                if not isinstance(item, dict):
+                    continue
+                fields = (
+                    ("abstractDeadline", "abstract", "Abstract Deadline"),
+                    ("deadline", "submission", "Paper Submission"),
+                )
+                for field, kind, label in fields:
+                    raw = item.get(field)
+                    if not raw:
+                        continue
+                    s = str(raw).strip()
+                    # 'Z' 로 끝나면 이미 UTC, 아니면 학회가 밝힌 타임존을 따른다.
+                    tz = "UTC" if s.endswith("Z") else (v.get("timezone") or "AoE")
+                    s = s.rstrip("Zz").replace("T", " ")
+                    note = item.get("note") if field == "deadline" else None
+                    deadlines.append(
+                        {"type": kind, "label": note or label, "date": s, "timezone": tz}
+                    )
+
+            if approx:
+                days = [d for d in (parse_day(d["date"]) for d in deadlines) if d]
+                if not days or min(days) > horizon:
+                    continue
+
+            entry = {
+                "id": str(v.get("id") or key),
+                "title": title,
+                "year": year,
+                "full_name": v.get("title"),
+                "link": v.get("website"),
+                "place": v.get("location"),
+                "hindex": v.get("h5Index"),
+                "tags": [TOBNA_TAG.get(t, normalize_tag(t)) for t in v.get("tags") or []],
+                "deadlines": deadlines,
+            }
+            if v.get("conferenceStartDate"):
+                entry["start"] = str(v["conferenceStartDate"])
+            if v.get("conferenceEndDate"):
+                entry["end"] = str(v["conferenceEndDate"])
+            if approx:
+                entry["approx"] = True
+            if not deadlines:
+                entry["tba"] = True
+            entries.append(entry)
+    return entries
+
+
+MONTHS = {
+    m: i
+    for i, m in enumerate(
+        ["January", "February", "March", "April", "May", "June", "July",
+         "August", "September", "October", "November", "December"],
+        start=1,
+    )
+}
+
+
+def parse_month_day(text, cycle_month, cycle_year):
+    """'March 16' 같은 연도 없는 날짜를 사이클 기준으로 해석한다.
+
+    사이클 시작 월보다 앞선 월이면 해를 넘긴 것으로 본다 (예: December 사이클의
+    January 마감).
+    """
+    m = re.search(r"([A-Z][a-z]+)\s+(\d{1,2})", str(text or ""))
+    if not m or m.group(1) not in MONTHS:
+        return None
+    month, day = MONTHS[m.group(1)], int(m.group(2))
+    year = cycle_year + 1 if month < cycle_month else cycle_year
+    try:
+        return dt.date(year, month, day)
+    except ValueError:
+        return None
+
+
+def parse_full_date(text):
+    """'August 2, 2026' → date. 일(day)이 없는 'January, 2027' 따위는 버린다."""
+    m = re.search(r"([A-Z][a-z]+)\s+(\d{1,2}),\s*(\d{4})", str(text or ""))
+    if not m or m.group(1) not in MONTHS:
+        return None
+    try:
+        return dt.date(int(m.group(3)), MONTHS[m.group(1)], int(m.group(2)))
+    except ValueError:
+        return None
+
+
+def aoe_deadline(day, kind, label):
+    """날짜만 아는 마감을 이 분야 관례(AoE 23:59)로 채운 deadline 항목을 만든다."""
+    return {
+        "type": kind,
+        "label": label,
+        "date": f"{day.isoformat()} 23:59:59",
+        "timezone": "AoE",
+    }
+
+
+def strip_markdown(cell):
+    """'[EMNLP 2026](https://...)' → 'EMNLP 2026'."""
+    return re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", str(cell or "")).strip()
+
+
+def parse_arr(text):
+    """aclrollingreview.org/dates 의 마크다운 표 두 개를 읽는다.
+
+    첫 표(Reviewing Schedule)에서는 리뷰 사이클별 주요 날짜를, 둘째 표(참여 학회)
+    에서는 학회별 ARR 최종 제출일과 commitment 날짜를 뽑는다. 반환은
+    (사이클 엔트리 목록, 학회별 마감 목록) 이다.
+    """
+    if not text:
+        return [], []
+
+    tables = []  # [(header_cells, [row_cells, ...]), ...]
+    current = None
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("|") and line.endswith("|"):
+            cells = [c.strip() for c in line.strip("|").split("|")]
+            if all(re.fullmatch(r":?-+:?", c) for c in cells):
+                continue  # 구분선
+            if current is None:
+                current = (cells, [])
+                tables.append(current)
+            else:
+                current[1].append(cells)
+        else:
+            current = None
+
+    cycles, venues = [], []
+    for header, rows in tables:
+        head = [h.lower() for h in header]
+        if "cycle" in head[0] and any("submission" in h for h in head):
+            cycles.extend(parse_arr_cycles(header, rows))
+        elif "venue" in head[0]:
+            venues.extend(parse_arr_venues(header, rows))
+    return cycles, venues
+
+
+def parse_arr_cycles(header, rows):
+    head = [h.lower() for h in header]
+
+    def col(name):
+        for i, h in enumerate(head):
+            if name in h:
+                return i
+        return None
+
+    columns = (
+        (col("submission"), "submission", "Submission"),
+        (col("author response"), "author_response", "Author Response Start"),
+        (col("meta-review"), "meta_review", "Meta-review Release"),
+        (col("cycle end"), "cycle_end", "Cycle End"),
+    )
+
+    entries = []
+    for row in rows:
+        m = re.match(r"([A-Z][a-z]+)\s+(\d{4})", strip_markdown(row[0]))
+        if not m or m.group(1) not in MONTHS:
+            continue
+        cycle_name = f"{m.group(1)} {m.group(2)}"
+        cycle_month, cycle_year = MONTHS[m.group(1)], int(m.group(2))
+
+        deadlines = []
+        cycle_end = None
+        for idx, kind, label in columns:
+            if idx is None or idx >= len(row):
+                continue
+            day = parse_month_day(row[idx], cycle_month, cycle_year)
+            if not day:
+                continue
+            deadlines.append(aoe_deadline(day, kind, label))
+            if kind == "cycle_end":
+                cycle_end = day
+
+        entry = {
+            "id": f"arr-{m.group(1).lower()}{str(cycle_year)[-2:]}",
+            "title": f"ARR ({cycle_name})",
+            "year": cycle_year,
+            "full_name": f"ACL Rolling Review — {cycle_name} cycle",
+            "link": "https://aclrollingreview.org/dates",
+            "tags": ["natural-language-processing"],
+            "timezone": "AoE",
+            "deadlines": deadlines,
+        }
+        if cycle_end:
+            # 사이클 종료일을 개최일처럼 취급해 지난 사이클이 정리되도록 한다.
+            entry["start"] = entry["end"] = cycle_end.isoformat()
+            entry["date"] = f"Cycle ends {cycle_end.strftime('%B %d, %Y')}"
+        if not deadlines:
+            entry["tba"] = True
+        entries.append(entry)
+    return entries
+
+
+def parse_arr_venues(header, rows):
+    head = [h.lower() for h in header]
+
+    def col(name):
+        for i, h in enumerate(head):
+            if name in h:
+                return i
+        return None
+
+    sub_i, commit_i = col("submission"), col("commitment")
+    venues = []
+    for row in rows:
+        names = strip_markdown(row[0])
+        link = re.search(r"\]\((https?://[^)]+)\)", row[0])
+        submission = parse_full_date(row[sub_i]) if sub_i is not None and sub_i < len(row) else None
+        commitment = parse_full_date(row[commit_i]) if commit_i is not None and commit_i < len(row) else None
+        if not submission and not commitment:
+            continue
+        for m in re.finditer(r"([A-Z][A-Za-z]*)\s+(\d{4})", names):
+            venues.append(
+                {
+                    "title": m.group(1),
+                    "year": int(m.group(2)),
+                    "submission": submission,
+                    "commitment": commitment,
+                    "link": link.group(1) if link else None,
+                }
+            )
+    return venues
 
 
 def load_yaml_dir(path):
@@ -352,11 +653,16 @@ def normalize(entry, source):
             record[key] = str(value).strip("'\"") if key in ("start", "end") else value
     if tba:
         record["tba"] = True
+    if entry.get("approx"):
+        record["approx"] = True
+    # NLP 계열은 AI 안에서도 따로 걸러 볼 수 있게 분류를 하나 더 붙인다.
+    if "natural-language-processing" in record["tags"] or base_title(title) in NLP_TITLES:
+        record["areas"] = sorted(set(record["areas"]) | {"NLP"})
     return record
 
 
 # 같은 학회가 여러 출처에 있을 때의 우선순위. 숫자가 작을수록 우선한다.
-SOURCE_PRIORITY = {"ai-deadlines": 0, "casys": 1, "idsl": 2}
+SOURCE_PRIORITY = {"ai-deadlines": 0, "casys": 1, "tobna": 2, "idsl": 3, "arr": 4}
 
 
 def dedupe(records):
@@ -372,12 +678,31 @@ def dedupe(records):
     for r in records:
         groups[(base_title(r["title"]), r["year"])][r["source"]].append(r)
 
+    def collapse(group):
+        """같은 출처 안의 표기만 다른 중복을 접는다.
+
+        진짜 라운드(ASPLOS (Spring) 등)는 괄호 라벨이 서로 다르므로 남고,
+        라벨까지 같은 중복은 실측·마감 정보가 많은 쪽 하나만 남긴다.
+        """
+        by_round = {}
+        for r in group:
+            key = round_label(r["title"])
+            cur = by_round.get(key)
+            if cur is None or (not r.get("approx"), len(r["deadlines"])) > (
+                not cur.get("approx"), len(cur["deadlines"])
+            ):
+                by_round[key] = r
+        return list(by_round.values())
+
     merged = []
     for buckets in groups.values():
+        buckets = {s: collapse(g) for s, g in buckets.items()}
         def rank(item):
             source, group = item
             deadline_count = sum(len(r["deadlines"]) for r in group)
-            return (len(group), deadline_count, -SOURCE_PRIORITY.get(source, 99))
+            # 예상(approx) 마감만 있는 출처보다 실측 마감이 있는 출처를 우선한다.
+            has_real = any(not r.get("approx") for r in group)
+            return (len(group), has_real, deadline_count, -SOURCE_PRIORITY.get(source, 99))
 
         source, chosen = max(buckets.items(), key=rank)
 
@@ -388,6 +713,69 @@ def dedupe(records):
             chosen[0]["areas"] = sorted(set(chosen[0]["areas"]) | extra_areas)
         merged.extend(chosen)
     return merged
+
+
+def merge_arr_venues(records, venues):
+    """ARR 참여 학회 표의 마감을 학회 레코드에 붙인다.
+
+    이미 있는 학회에는 없는 종류의 마감(ARR 최종 제출, commitment)만 더하고,
+    다른 출처에 아직 없는 학회(예: 다음 해 NAACL)는 새 레코드로 만든다.
+    """
+    # 'EMNLP (System Demonstrations Track)' 같은 라운드/트랙 표기가 아니라
+    # 본 학회 레코드에 마감이 붙도록, 괄호 없는 제목을 우선해 색인한다.
+    by_key = {}
+    for r in records:
+        key = (base_title(r["title"]), r["year"])
+        if key not in by_key or (
+            round_label(by_key[key]["title"]) and not round_label(r["title"])
+        ):
+            by_key[key] = r
+    created = 0
+    for v in venues:
+        pairs = [
+            (v.get("submission"), "arr_submission", "ARR Final Submission"),
+            (v.get("commitment"), "commitment", "ARR Commitment"),
+        ]
+        record = by_key.get((base_title(v["title"]), v["year"]))
+        if record is None:
+            entry = {
+                "id": f"{v['title'].lower()}{str(v['year'])[-2:]}",
+                "title": v["title"],
+                "year": v["year"],
+                "link": v.get("link"),
+                "tags": ["natural-language-processing"],
+                "note": "Submissions via ACL Rolling Review",
+                "deadlines": [
+                    aoe_deadline(day, kind, label) for day, kind, label in pairs if day
+                ],
+            }
+            record = normalize(entry, "arr")
+            if record is None:
+                continue
+            records.append(record)
+            by_key[(base_title(record["title"]), record["year"])] = record
+            created += 1
+            continue
+
+        existing_types = {d["type"] for d in record["deadlines"]}
+        existing_utc = {d["utc"] for d in record["deadlines"]}
+        added = False
+        for day, kind, label in pairs:
+            if not day or kind in existing_types:
+                continue
+            # 출처만 다른 같은 마감(예: HF 의 commitment_deadline)은 다시 넣지 않는다.
+            if kind == "commitment" and any("commitment" in t for t in existing_types):
+                continue
+            d = aoe_deadline(day, kind, label)
+            d["utc"] = to_utc(d["date"], d["timezone"])
+            if d["utc"] and d["utc"] not in existing_utc:
+                record["deadlines"].append(d)
+                added = True
+        if added:
+            record["deadlines"].sort(key=lambda d: d["utc"])
+    if created:
+        print(f"ARR 참여 학회 {created}건을 새로 추가")
+    return records
 
 
 def prune_and_sort(records, today):
@@ -417,9 +805,13 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--hf-dir", help="이미 받아둔 ai-deadlines clone 경로")
     ap.add_argument("--casys-dir", help="이미 받아둔 casys-kaist.github.io clone 경로")
+    ap.add_argument("--tobna-dir", help="이미 받아둔 tobna/ai-deadlines clone 경로")
     ap.add_argument("--idsl-file", help="이미 받아둔 추가 출처 데이터 파일 경로")
+    ap.add_argument("--arr-file", help="이미 받아둔 ARR dates.md 파일 경로")
     ap.add_argument("--output", default=OUTPUT)
     args = ap.parse_args()
+
+    today = dt.date.today()
 
     with tempfile.TemporaryDirectory() as tmp:
         if args.hf_dir:
@@ -432,26 +824,43 @@ def main():
             casys_path = sparse_clone(
                 CASYS_REPO, CASYS_DATA_PATH, os.path.join(tmp, "casys")
             )
+        if args.tobna_dir:
+            tobna_path = os.path.join(args.tobna_dir, TOBNA_DATA_PATH)
+        else:
+            tobna_path = sparse_clone(
+                TOBNA_REPO, TOBNA_DATA_PATH, os.path.join(tmp, "tobna")
+            )
 
         raw = [(e, "ai-deadlines") for e in load_yaml_dir(hf_path)]
         raw += [(e, "casys") for e in load_yaml_dir(casys_path)]
+        raw += [(e, "tobna") for e in parse_tobna(tobna_path, today)]
 
     if args.idsl_file:
         with open(args.idsl_file, encoding="utf-8") as fh:
             idsl_text = fh.read()
     else:
-        idsl_text = fetch_idsl(IDSL_URL)
-    idsl_entries = parse_idsl(idsl_text)
-    raw += [(e, "idsl") for e in idsl_entries]
+        idsl_text = fetch_text(IDSL_URL, "IDSL")
+    raw += [(e, "idsl") for e in parse_idsl(idsl_text)]
+
+    if args.arr_file:
+        with open(args.arr_file, encoding="utf-8") as fh:
+            arr_text = fh.read()
+    else:
+        arr_text = fetch_text(ARR_URL, "ARR")
+    arr_cycles, arr_venues = parse_arr(arr_text)
+    raw += [(e, "arr") for e in arr_cycles]
+    print(f"ARR 리뷰 사이클 {len(arr_cycles)}건, 참여 학회 마감 {len(arr_venues)}건")
 
     records = [n for n in (normalize(e, s) for e, s in raw) if n]
     before = {r["source"]: 0 for r in records}
     for r in records:
         before[r["source"]] += 1
     records = dedupe(records)
-    added = sum(1 for r in records if r["source"] == "idsl")
-    print(f"추가 출처 {before.get('idsl', 0)}건 중 {added}건이 신규 (나머지는 중복)")
-    records = prune_and_sort(records, dt.date.today())
+    for src, label in (("tobna", "aideadlines.org"), ("idsl", "IDSL")):
+        added = sum(1 for r in records if r["source"] == src)
+        print(f"{label} {before.get(src, 0)}건 중 {added}건이 신규 (나머지는 중복)")
+    records = merge_arr_venues(records, arr_venues)
+    records = prune_and_sort(records, today)
 
     if not records:
         print("동기화 결과가 비어 있어 기존 파일을 유지한다.", file=sys.stderr)


### PR DESCRIPTION
- aideadlines.org(tobna/ai-deadlines) 를 네 번째 출처로 추가해 ACL, EACL, IJCNLP, CoNLL, LREC, NLPCC, KDD, WWW, ICML 등 누락 학회 51건을 보강
- aclrollingreview.org/dates 의 ARR 리뷰 사이클 일정과 참여 학회별 commitment 마감을 파싱해 함께 표시 (*ACL 계열은 ARR 제출로 이뤄지므로)
- 공식 발표 전 추정 일정은 '예상 마감' 배지로 구분하고, 400일 이내 것만 수록
- 같은 출처 안의 표기 중복(CEC/IEEE CEC 등)을 정리하는 collapse 단계 추가
- 페이지에 NLP 필터 버튼과 다음 마감의 종류 라벨(Submission, ARR Commitment 등) 표시 추가
- 주간 자동 동기화 워크플로는 같은 스크립트를 실행하므로 새 출처도 자동으로 갱신됨


Claude-Session: https://claude.ai/code/session_01W5j7bzqSNQRd2xDLyanxc7